### PR TITLE
Cppmethods

### DIFF
--- a/gen.rs
+++ b/gen.rs
@@ -667,7 +667,10 @@ fn cty_to_rs(ctx: &mut GenCtx, ty: @Type) -> ast::Ty {
         TEnum(ei) => {
             ei.name = unnamed_name(ctx, copy ei.name);
             mk_ty(ctx, enum_name(copy ei.name))
-        }
+        },
+		TMemberFunc(_,_,_,_) => {
+			mk_ty(ctx,~"c_void")
+		}
     };
 }
 

--- a/main.rs
+++ b/main.rs
@@ -25,6 +25,7 @@ enum ParseResult {
     ParseErr(~str)
 }
 
+
 fn parse_args(args: &[~str]) -> ParseResult {
     let mut clang_args = ~[];
     let args_len = args.len();
@@ -326,11 +327,11 @@ fn read_function_args(cursor: &Cursor, ctx: @mut BindGenCtx)->~[ArgInfo] {
 
 fn debug_show_args(args:&[ArgInfo]) {
 	// TODO - use more idiomatic rust iteration
-	println(fmt!("\tnum args = %u\n", args.len()));
+	//dblog!("\tnum args = %u\n", args.len());
 	let mut i=0;
 	while i<args.len() {
 		let (ref argName,argType)=args[i];
-		println(fmt!("\t\targ %u %s:%s\n",i,*argName,argType.to_str()));
+		//dblog!("\t\targ %u %s:%s\n",i,*argName,argType.to_str());
 		i+=1;
 	}
 }
@@ -347,7 +348,7 @@ fn visit_struct(cursor: &Cursor,
 		}
 		CXCursor_CXXMethod=>{
 			use types::*;
-			println(fmt!("\tmember function %s\n", cursor.spelling()));
+			//dblog!("\tmember function %s\n", cursor.spelling());
 			let args = read_function_args(cursor, ctx);
 			debug_show_args(args);
 			ci.methods.push(//mk_methodinfo(ty,name,args)
@@ -359,7 +360,7 @@ fn visit_struct(cursor: &Cursor,
 			);
 		}
 		_=>{
-			println(fmt!("\tstruct member unknown %s\n", cursor.spelling()));
+			//dblog!("\tstruct member unknown %s\n", cursor.spelling());
 		}
 	}
     return CXChildVisit_Continue;
@@ -402,10 +403,10 @@ fn visit_top<'r>(cur: &'r Cursor,
     if !match_pattern(ctx, cursor) {
         return CXChildVisit_Continue;
     }
-	let mut indent= ~"";
-	for depth.times { indent.append("\t");}
+	//let mut indent= ~"";
+	//for depth.times { indent.append("\t");}
+	//dblog!("%svisit -%s\n", indent,cursor.spelling());
 
-	println(fmt!("%svisit -%s\n", indent,cursor.spelling()));
     match cursor.kind() {
       CXCursor_StructDecl => {
         do fwd_decl(ctx, cursor) || {

--- a/makefile
+++ b/makefile
@@ -1,5 +1,8 @@
 bindgen: bindgen.rs gen.rs main.rs types.rs clangll.rs
-	rustc main.rs -L$LLVM_LIB
+	rustc bindgen.rs -L $(LLVM_LIB)
 
 testcpp: bindgen
-	./bindgen -x c++ testbindgen.h
+	./bindgen -x c++ test_bindgen_cpp.h
+
+clean:
+	rm ./bindgen

--- a/makefile
+++ b/makefile
@@ -1,0 +1,5 @@
+bindgen: bindgen.rs gen.rs main.rs types.rs clangll.rs
+	rustc main.rs -L$LLVM_LIB
+
+testcpp: bindgen
+	./bindgen -x c++ testbindgen.h

--- a/test_bindgen_cpp.h
+++ b/test_bindgen_cpp.h
@@ -1,0 +1,22 @@
+//
+// test header for cpp support in bindgen
+//
+
+int foo(int, int, int);
+float* foo2(int, const char* txt[7], int*);
+void foo3(int);
+
+struct Foo {
+	float x,y,z;
+	const char* name;
+	void bar(int x,float y);
+	const char* getBaz(const void* src);
+	struct Nested_s {
+		int nx,ny;
+		int getOrange(int) const;
+	} m_nested;
+};
+
+enum ETest {
+	E_1,E_2,E_3
+};

--- a/testbindgen.h
+++ b/testbindgen.h
@@ -1,0 +1,19 @@
+
+int foo(int, int, int);
+float* foo2(int, const char* txt[7], int*);
+void foo3(int);
+
+struct Foo {
+	float x,y,z;
+	const char* name;
+	void bar(int x,float y);
+	const char* getBaz(const void* src);
+	struct Nested_s {
+		int nx,ny;
+		int getOrange(int) const;
+	} m_nested;
+};
+
+enum ETest {
+	E_1,E_2,E_3
+};

--- a/types.rs
+++ b/types.rs
@@ -11,18 +11,42 @@ pub enum Global {
     GOther
 }
 
+
+pub type ReturnType=Type;
+pub type ReceiverType=Type;
+pub type ArgType=Type;
+pub type ArgInfo=(~str,@ArgType);
+pub type FuncInfo=(@ReturnType,~str,~[ArgInfo],bool);
+
 pub enum Type {
     TVoid,
     TInt(IKind),
     TFloat(FKind),
     TPtr(@Type, bool),
     TArray(@Type, uint),
-    TFunc(@Type, ~[(~str, @Type)], bool),
+    TFunc(@ReturnType,		~[ArgInfo],	bool),
+	TMemberFunc(@ReturnType,	@ReceiverType,~[ArgInfo],	bool),
     TNamed(@mut TypeInfo),
     TComp(@mut CompInfo),
     TEnum(@mut EnumInfo)
 }
+//?? didn't work as impl ToStr for Type ?
+impl Type {
+	pub fn to_str(@self)->~str {
+		match self {
+			@TVoid => ~"void-to_str_TODO",
+			@TInt(k) => ~"Int-to_str_TODO",
+			@TFloat(k) => ~"Float-to_str_TODO",
+			@TPtr(k,b) => ~"Ptr-to_str_TODO",
 
+			@TMemberFunc(ref rett,ref rect,ref args,ref var)=>
+				~"MemberFunction-to_str_TODO",
+			_ =>~"Type-to_str_TODO"
+		}	
+	}
+}
+
+#[deriving(ToStr)]
 pub enum IKind {
     IBool,
     ISChar,
@@ -37,16 +61,26 @@ pub enum IKind {
     IULongLong
 }
 
+#[deriving(ToStr)]
 pub enum FKind {
     FFloat,
     FDouble
 }
 
+pub struct MethodInfo {
+	return_type:~str,
+	name:~str,
+	args:~[@ArgInfo]
+}
+
+
 pub struct CompInfo {
     cstruct: bool,
     name: ~str,
     fields: ~[@FieldInfo]
+//	methods: ~[~MethodInfo]
 }
+
 
 pub struct FieldInfo {
     name: ~str,
@@ -54,11 +88,13 @@ pub struct FieldInfo {
     bit: Option<uint>
 }
 
+
 pub struct EnumInfo {
     name: ~str,
     items: ~[@EnumItem],
     kind: IKind
 }
+
 
 pub struct EnumItem {
     name: ~str,
@@ -118,6 +154,7 @@ pub fn mk_compinfo(name: ~str, cstruct: bool, fields: ~[@FieldInfo]) -> @mut Com
     return @mut CompInfo { cstruct: cstruct,
                            name: name,
                            fields: fields
+//							methods: ~[]
                          };
 }
 
@@ -209,7 +246,8 @@ pub fn type_align(ty: @Type) -> uint {
         },
         TEnum(_) => 4,
         TVoid => 0,
-        TFunc(_, _, _) => 0
+        TFunc(_, _, _) => 0,
+        TMemberFunc(_,_,_,_) => 0,
     };
 }
 
@@ -274,7 +312,8 @@ pub fn type_size(ty: @Type) -> uint {
         },
         TEnum(_) => 4,
         TVoid => 0,
-        TFunc(_, _, _) => 0
+        TFunc(_, _, _) => 0,
+		TMemberFunc(_,_,_,_)=>0
     };
 }
 

--- a/types.rs
+++ b/types.rs
@@ -68,17 +68,17 @@ pub enum FKind {
 }
 
 pub struct MethodInfo {
-	return_type:~str,
+	return_type:@Type,
 	name:~str,
-	args:~[@ArgInfo]
+	args:~[ArgInfo]
 }
 
 
 pub struct CompInfo {
     cstruct: bool,
     name: ~str,
-    fields: ~[@FieldInfo]
-//	methods: ~[~MethodInfo]
+    fields: ~[@FieldInfo],
+	methods: ~[@MethodInfo]
 }
 
 
@@ -153,8 +153,8 @@ impl ToStr for VarInfo {
 pub fn mk_compinfo(name: ~str, cstruct: bool, fields: ~[@FieldInfo]) -> @mut CompInfo {
     return @mut CompInfo { cstruct: cstruct,
                            name: name,
-                           fields: fields
-//							methods: ~[]
+                           fields: fields,
+							methods: ~[]
                          };
 }
 

--- a/types.rs
+++ b/types.rs
@@ -327,7 +327,7 @@ pub fn type_size(ty: @Type) -> uint {
             ILong | IULong => 4,
             ILongLong | IULongLong => 8
         },
-        TFloat(k) => match k {
+        TFloat(k) => match k {	
             FFloat => 4,
             FDouble => 8
         },


### PR DESCRIPTION
Please you could review and consider my changes to add some sort of limited CPP support to the binding generator.
I'm only intending to handle a tiny subset of C++ , but i can rework my own C++ sources for easier rust interop.
any ideas and feedback welcome

"make testcpp" to run the example

My first stage is here, I generate fn classname_methodname(&classname..) fn's for CPP methods found in a struct/class - along with a wrapper impl rust side ..


impl StructName  {
    methodname(self..) {  StructName_methodname(self, ... )}
    ..
}

I intend to make rust-bindgen spit out the corresponding C++ side function calls.

I would also like to add rudimentary substitution of some templates; ive written a read-only rust equivalent of std::vector, and figure it might be possible to find field instantiations that use them and replace with the rust equivalent. (I haven't got far with this yet..)

If you have any ideas on this, suggestions for better approaches etc, i'd we interested to hear
I'm new to rust obviously and if you can suggest ways to improve my modifications to make integrating easier then great.

i modified a couple of the original functions & structs .. cfunc_args_to_rs returns the argument-name list as a second parameter.. and added [Methods] to CComp

I hope that these additions can go in orthogonally to the underlying C support.. (leaving fields empty)
I realise that adding complexity is a worry

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crabtw/rust-bindgen/33)
<!-- Reviewable:end -->
