### PR TITLE
Adds Default impls for generated composites.

### DIFF
--- a/tests/support.rs
+++ b/tests/support.rs
@@ -1,15 +1,15 @@
 use bindgen;
 use bindgen::{Logger, BindgenOptions};
-use std::default::Default;
-use std::fmt;
-use syntax::ast;
-use syntax::print::pprust;
-use syntax::ptr::P;
 
+use std::default::Default;
+
+use syntax::ast;
 use syntax::codemap;
 use syntax::codemap::{Span, DUMMY_SP};
 use syntax::parse;
 use syntax::parse::token;
+use syntax::print::pprust;
+use syntax::ptr::P;
 
 struct TestLogger;
 
@@ -33,10 +33,13 @@ pub fn generate_bindings(filename: &str) -> Result<Vec<P<ast::Item>>, ()> {
 
 pub fn test_bind_eq(filename: &str, f:|ext_cx: DummyExtCtxt| -> Vec<Option<P<ast::Item>>>) {
     let ext_cx = mk_dummy_ext_ctxt();
-    let items = normalize_attr_ids(generate_bindings(filename).unwrap());
-    let quoted = normalize_attr_ids(f(ext_cx).into_iter().map(|x| x.unwrap()).collect());
-    assert_eq!(PrettyItems { items: items },
-               PrettyItems { items: quoted });
+    let items = generate_bindings(filename).unwrap();
+    let quoted =f(ext_cx).into_iter().map(|x| x.unwrap()).collect();
+
+    // The ast::Items themselves have insignificant (for our purposes)
+    // differences that make them difficult to compare directly.  So, compare
+    // rendered versions, which is not beautiful, but should work.
+    assert_eq!(render_items(&quoted), render_items(&items));
 }
 
 macro_rules! assert_bind_eq {
@@ -46,6 +49,17 @@ macro_rules! assert_bind_eq {
             vec!($($quote),*)
         });
     }
+}
+
+fn render_items(items: &Vec<P<ast::Item>>) -> String {
+    pprust::to_string(|s| {
+        let module = ast::Mod {
+            inner: DUMMY_SP,
+            view_items: Vec::new(),
+            items: items.clone(),
+        };
+        s.print_mod(&module, &[])
+    })
 }
 
 pub struct DummyExtCtxt {
@@ -76,145 +90,4 @@ impl DummyExtCtxt {
 
 fn mk_dummy_ext_ctxt<'a>() -> DummyExtCtxt {
     DummyExtCtxt { sess: parse::new_parse_sess() }
-}
-
-#[deriving(PartialEq)]
-struct PrettyItems {
-    pub items: Vec<P<ast::Item>>,
-}
-
-impl fmt::Show for PrettyItems {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let output = pprust::to_string(|s| {
-            let module = ast::Mod {
-                inner: DUMMY_SP,
-                view_items: Vec::new(),
-                items: self.items.clone(),
-            };
-            s.print_mod(&module, &[])
-        });
-        write!(f, "\n{}\n", output)
-    }
-}
-
-// libsyntax uses a thread-local variable to create unique AttrId values during
-// parsing and quoting.  normalize_attr_ids makes sure that all AttrId values
-// for the passed `items` start at zero and proceed upward.  This is necessary
-// to correctly compare otherwise-identical ASTs.
-fn normalize_attr_ids(items: Vec<P<ast::Item>>) -> Vec<P<ast::Item>> {
-    use std::mem;
-    use syntax::visit::*;
-
-    struct Vis<'a> {
-        attr_id: uint,
-        items: Vec<P<ast::Item>>,
-    }
-
-    impl<'a> Vis<'a> {
-        // TODO: visit_crate?  ast::visit::Visitor does not deal with them directly,
-        //       but concievably, it could eventually come up.
-
-        fn rewrite_attrs(&mut self, attrs: Vec<ast::Attribute>) -> Vec<ast::Attribute> {
-            attrs.into_iter().map(|mut attr| {
-                attr.node.id = ast::AttrId(self.attr_id);
-                self.attr_id += 1;
-                attr
-            }).collect()
-        }
-    }
-
-    unsafe fn force_mutable<T>(x: &T) -> &mut T {
-        mem::transmute(x)
-    }
-
-    macro_rules! rewrite_attrs {
-        ($self_:ident, $item:expr) => {
-            unsafe {
-                let unsafe_item = force_mutable($item);
-                let new_attrs = mem::replace(&mut unsafe_item.attrs, vec!());
-                let new_attrs = $self_.rewrite_attrs(new_attrs);
-                mem::replace(&mut unsafe_item.attrs, new_attrs);
-            }
-        }
-    }
-
-    impl<'a, 'v> Visitor<'v> for Vis<'a> {
-        fn visit_item(&mut self, i: &ast::Item) {
-            rewrite_attrs!(self, i);
-
-            match i.node {
-                ast::ItemImpl(_, _, _, _, ref impl_items) => {
-                    for impl_item in impl_items.iter() {
-                        match *impl_item {
-                            ast::ImplItem::MethodImplItem(_) => { }
-                            ast::ImplItem::TypeImplItem(ref typedef) => {
-                                rewrite_attrs!(self, typedef.deref());
-                            }
-                        }
-                    }
-                }
-                _ => { }
-            }
-
-            walk_item(self, i);
-        }
-
-        fn visit_foreign_item(&mut self, i: &ast::ForeignItem) {
-            rewrite_attrs!(self, i);
-            walk_foreign_item(self, i);
-        }
-
-        fn visit_fn(&mut self, fk: FnKind, fd: &ast::FnDecl, b: &ast::Block, s: Span, _: ast::NodeId) {
-            match fk {
-                FkItemFn(_, _, _, _) | FkFnBlock => { }
-                FkMethod(_, _, method) => {
-                    rewrite_attrs!(self, method);
-                }
-            }
-            walk_fn(self, fk, fd, b, s);
-        }
-
-        fn visit_arm(&mut self, a: &ast::Arm) {
-            rewrite_attrs!(self, a);
-            walk_arm(self, a);
-        }
-
-        fn visit_ty_method(&mut self, t: &ast::TypeMethod) {
-            rewrite_attrs!(self, t);
-            walk_ty_method(self, t);
-        }
-
-        fn visit_variant(&mut self, v: &ast::Variant, g: &ast::Generics) {
-            rewrite_attrs!(self, &v.node);
-            walk_variant(self, v, g);
-        }
-
-        fn visit_view_item(&mut self, i: &ast::ViewItem) {
-            rewrite_attrs!(self, i);
-            walk_view_item(self, i);
-        }
-
-        fn visit_struct_field(&mut self, s: &ast::StructField) {
-            rewrite_attrs!(self, &s.node);
-            walk_struct_field(self, s);
-        }
-
-        fn visit_trait_item(&mut self, t: &ast::TraitItem) {
-            match *t {
-                ast::TraitItem::RequiredMethod(_) |
-                ast::TraitItem::ProvidedMethod(_) => { }
-                ast::TraitItem::TypeTraitItem(ref assoc_ty) => {
-                    rewrite_attrs!(self, assoc_ty.deref());
-                }
-            }
-            walk_trait_item(self, t);
-        }
-    }
-
-    let mut visitor = Vis { attr_id: 0, items: vec!() };
-    for item in items.into_iter() {
-        visitor.visit_item(item.deref());
-        visitor.items.push(item);
-    }
-    visitor.items
 }

--- a/tests/test_builtins.rs
+++ b/tests/test_builtins.rs
@@ -1,12 +1,6 @@
-#![feature(phase)]
-
-#[phase(plugin)]
-extern crate bindgen;
-
-extern crate libc;
-
 #[test]
 fn test_builtin_va_list() {
+    #[allow(dead_code, non_camel_case_types, raw_pointer_deriving)]
     mod ffi { bindgen!("headers/builtin_va_list.h", emit_builtins = true); }
     // Should test for more than compilation.
 }

--- a/tests/test_func.rs
+++ b/tests/test_func.rs
@@ -22,6 +22,11 @@ fn func_ptr_in_struct() {
                     extern "C" fn(x: ::libc::c_int,
                                   y: ::libc::c_int) -> Enum_baz>,
             }
+        ),
+        quote_item!(cx,
+            impl ::std::default::Default for Struct_Foo {
+                fn default() -> Struct_Foo { unsafe { ::std::mem::zeroed() } }
+            }
         )
     );
 }

--- a/tests/test_union.rs
+++ b/tests/test_union.rs
@@ -1,9 +1,11 @@
+use std::default::Default;
+
 #[test]
 fn with_anon_struct() {
     // XXX: Rustc thinks that the anonymous struct, bar, is unused.
     #[allow(dead_code)]
     mod ffi { bindgen!("headers/union_with_anon_struct.h"); }
-    let mut x = ffi::Union_foo { _bindgen_data_: [0, 0] };
+    let mut x: ffi::Union_foo = Default::default();
 
     unsafe {
         (*x.bar()).a = 0x12345678;
@@ -17,7 +19,7 @@ fn with_anon_struct() {
 #[test]
 fn with_anon_union() {
     mod ffi { bindgen!("headers/union_with_anon_union.h"); }
-    let mut x = ffi::Union_foo { _bindgen_data_: [0] };
+    let mut x: ffi::Union_foo = Default::default();
 
     unsafe {
         *(*x.bar()).a() = 0x12345678;
@@ -30,7 +32,7 @@ fn with_anon_union() {
 #[test]
 fn with_anon_unnamed_struct() {
     mod ffi { bindgen!("headers/union_with_anon_unnamed_struct.h"); }
-    let mut x = ffi::Union_pixel { _bindgen_data_: [0] };
+    let mut x: ffi::Union_pixel = Default::default();
 
     unsafe {
         *x.r() = 0xca;
@@ -49,7 +51,7 @@ fn with_anon_unnamed_struct() {
 #[test]
 fn with_anon_unnamed_union() {
     mod ffi { bindgen!("headers/union_with_anon_unnamed_union.h"); }
-    let mut x = ffi::Union_foo { _bindgen_data_: [0] };
+    let mut x: ffi::Union_foo = Default::default();
 
     unsafe {
         *x.a() = 0x12345678;
@@ -63,7 +65,7 @@ fn with_anon_unnamed_union() {
 #[test]
 fn with_nesting() {
     mod ffi { bindgen!("headers/union_with_nesting.h"); }
-    let mut x = ffi::Union_foo { _bindgen_data_: [0] };
+    let mut x: ffi::Union_foo = Default::default();
 
     unsafe {
         *x.a() = 0x12345678;
@@ -73,5 +75,20 @@ fn with_nesting() {
         assert_eq!(*x.b2(), 0x5678);
         assert_eq!(*x.c1(), 0x1234);
         assert_eq!(*x.c2(), 0x1234);
+    }
+}
+
+#[test]
+fn default_impl() {
+    mod ffi { bindgen!("headers/Union_with_nesting.h"); }
+
+    let mut x: ffi::Union_foo = Default::default();
+
+    unsafe {
+        assert_eq!(*x.a(), 0);
+        assert_eq!(*x.b1(), 0);
+        assert_eq!(*x.b2(), 0);
+        assert_eq!(*x.c1(), 0);
+        assert_eq!(*x.c2(), 0);
     }
 }


### PR DESCRIPTION
gen.rs
- Structs and unions now emit an implementation of the `Default` trait
  using `std::mem::zeroed` to create a zeroed instance.

tests/support.rs
- AST comparisons are now done on the pretty-printed version of the
  ASTs.  Differences in AttrIds and some identifiers (generated with
  gensym to ensure uniqueness) made it unreliable to compare the ASTs
  directly.  This way should work, even if it doesn't score many points
  for style.

tests/*
- Updated to use `Default::default()` where appropriate.
- Eliminated a few warnings.