### PR TITLE
Use usize/us instead of uint/u in generated code

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -1020,7 +1020,7 @@ fn mk_ptrty(ctx: &mut GenCtx, base: &ast::Ty, is_const: bool) -> ast::Ty {
 }
 
 fn mk_arrty(ctx: &GenCtx, base: &ast::Ty, n: usize) -> ast::Ty {
-    let int_lit = ast::LitInt(n as u64, ast::UnsignedIntLit(ast::TyUs(true)));
+    let int_lit = ast::LitInt(n as u64, ast::UnsignedIntLit(ast::TyUs(false)));
     let sz = ast::ExprLit(P(respan(ctx.span, int_lit)));
     let ty = ast::TyFixedLengthVec(
         P(base.clone()),


### PR DESCRIPTION
Currently, in generated code, fixed-sized array types are outputted using the 'u' integer suffix instead of the 'us' suffix. ie. `[::libc::c_uchar; 12u]` instead of `[::libc::c_uchar; 12us]`. This causes generated code to generate loads of warnings.

Fixing this is as simple as telling the pretty printer that we're using the non-deprecated integer types instead of the deprecated ones.

