### PR TITLE
Update unboxed closure syntax.

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -20,7 +20,7 @@ pub struct Cursor {
     x: CXCursor
 }
 
-pub type CursorVisitor<'s> = for<'a, 'b> FnMut<(&'a Cursor, &'b Cursor), Enum_CXChildVisitResult> + 's;
+pub type CursorVisitor<'s> = for<'a, 'b> FnMut(&'a Cursor, &'b Cursor) -> Enum_CXChildVisitResult + 's;
 
 impl Cursor {
     // common
@@ -61,7 +61,7 @@ impl Cursor {
     }
 
     pub fn visit<F>(&self, func:F)
-        where F: for<'a, 'b> FnMut<(&'a Cursor, &'b Cursor), Enum_CXChildVisitResult>
+        where F: for<'a, 'b> FnMut(&'a Cursor, &'b Cursor) -> Enum_CXChildVisitResult
     {
         let mut data: Box<CursorVisitor> = Box::new(func);
         let opt_visit = Some(visit_children as extern "C" fn(CXCursor, CXCursor, CXClientData) -> Enum_CXChildVisitResult);


### PR DESCRIPTION
I was unable to compile rust-bindgen with the newest nightly.
Problem seems to have been the unboxed closure syntax, so
I quickly updated it.