### PR TITLE
Allow build script to search libclang.so on multiple directories on Linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,13 @@
-use std::os;
+#![feature(path, io, env)]
+
+use std::env;
 use std::old_io::fs::PathExtensions;
 
 const LINUX_CLANG_DIRS: &'static [&'static str] = &["/usr/lib", "/usr/lib/llvm", "/usr/lib64/llvm"];
 const MAC_CLANG_DIR: &'static str = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
 
 fn main() {
-    let possible_clang_dirs = if let Some(dir) = os::getenv("LIBCLANG_PATH") {
+    let possible_clang_dirs = if let Ok(dir) = env::var_string("LIBCLANG_PATH") {
         vec![dir]
     } else if cfg!(any(target_os = "linux", target_os = "freebsd")) {
         LINUX_CLANG_DIRS.iter().map(ToString::to_string).collect()
@@ -15,7 +17,7 @@ fn main() {
         panic!("Platform not supported");
     };
 
-    let clang_lib = os::dll_filename("clang");
+    let clang_lib = format!("{}clang{}", env::consts::DLL_PREFIX, env::consts::DLL_SUFFIX);
 
     let maybe_clang_dir = possible_clang_dirs.into_iter().filter_map(|candidate_dir| {
         let clang_dir = Path::new(candidate_dir);

--- a/src/bgmacro.rs
+++ b/src/bgmacro.rs
@@ -124,7 +124,7 @@ fn parse_macro_opts(cx: &mut base::ExtCtxt, tts: &[ast::TokenTree], visit: &mut 
             match parser.bump_and_get() {
                 token::Ident(ident, _) => {
                     let ident = parser.id_to_interned_str(ident);
-                    name = Some(ident.get().to_string());
+                    name = Some((*ident).to_string());
                     parser.expect(&token::Eq);
                 },
                 _ => {
@@ -142,7 +142,7 @@ fn parse_macro_opts(cx: &mut base::ExtCtxt, tts: &[ast::TokenTree], visit: &mut 
                 parser.bump();
                 
                 // Bools are simply encoded as idents
-                let ret = match val.get() {
+                let ret = match (*val).as_slice() {
                     "true" => visit.visit_bool(as_str(&name), true),
                     "false" => visit.visit_bool(as_str(&name), false),
                     val => visit.visit_ident(as_str(&name), val)
@@ -159,7 +159,7 @@ fn parse_macro_opts(cx: &mut base::ExtCtxt, tts: &[ast::TokenTree], visit: &mut 
                 match expr.node {
                     ast::ExprLit(ref lit) => {
                         let ret = match lit.node {
-                            ast::LitStr(ref s, _) => visit.visit_str(as_str(&name), s.get()),
+                            ast::LitStr(ref s, _) => visit.visit_str(as_str(&name), (*s).as_slice()),
                             ast::LitBool(b) => visit.visit_bool(as_str(&name), b),
                             ast::LitInt(i, ast::SignedIntLit(_, sign)) |
                             ast::LitInt(i, ast::UnsuffixedIntLit(sign)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![crate_name = "bindgen"]
 #![crate_type = "dylib"]
-#![feature(quote, plugin_registrar, unboxed_closures)]
+#![feature(quote, plugin_registrar, unboxed_closures, rustc_private, libc)]
 
 extern crate syntax;
 extern crate rustc;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -207,7 +207,7 @@ fn mk_fn_sig(ctx: &mut ClangParserCtx, ty: &cx::Type, cursor: &Cursor) -> il::Fu
             // For non-CXCursor_FunctionDecl, visiting the cursor's children is
             // the only reliable way to get parameter names.
             let mut args_lst = vec!();
-            cursor.visit(|&mut: c: &Cursor, _: &Cursor| {
+            cursor.visit(|c: &Cursor, _: &Cursor| {
                 if c.kind() == CXCursor_ParmDecl {
                     args_lst.push((c.spelling(), conv_ty(ctx, &c.cur_type(), c)));
                 }
@@ -415,13 +415,13 @@ fn visit_composite(cursor: &Cursor, parent: &Cursor,
             }
         }
         CXCursor_StructDecl | CXCursor_UnionDecl => {
-            fwd_decl(ctx, cursor, |: ctx_| {
+            fwd_decl(ctx, cursor, |ctx_| {
                 // If the struct is anonymous (i.e. declared here) then it
                 // cannot be used elsewhere and so does not need to be added
                 // to globals otherwise it will be declared later and a global.
                 let decl = decl_name(ctx_, cursor);
                 let ci = decl.compinfo();
-                cursor.visit(|&mut: c, p| {
+                cursor.visit(|c, p| {
                     let mut ci_ = ci.borrow_mut();
                     visit_composite(c, p, ctx_, &mut ci_.members)
                 });
@@ -461,10 +461,10 @@ fn visit_top<'r>(cursor: &Cursor,
 
     match cursor.kind() {
         CXCursor_StructDecl | CXCursor_UnionDecl => {
-            fwd_decl(ctx, cursor, |: ctx_| {
+            fwd_decl(ctx, cursor, |ctx_| {
                 let decl = decl_name(ctx_, cursor);
                 let ci = decl.compinfo();
-                cursor.visit(|&mut: c, p| {
+                cursor.visit(|c, p| {
                     let mut ci_ = ci.borrow_mut();
                     visit_composite(c, p, ctx_, &mut ci_.members)
                 });
@@ -473,10 +473,10 @@ fn visit_top<'r>(cursor: &Cursor,
             return CXChildVisit_Continue;
         }
         CXCursor_EnumDecl => {
-            fwd_decl(ctx, cursor, |: ctx_| {
+            fwd_decl(ctx, cursor, |ctx_| {
                 let decl = decl_name(ctx_, cursor);
                 let ei = decl.enuminfo();
-                cursor.visit(|&mut: c, _: &Cursor| {
+                cursor.visit(|c, _: &Cursor| {
                     let mut ei_ = ei.borrow_mut();
                     visit_enum(c, &mut ei_.items)
                 });
@@ -585,10 +585,10 @@ pub fn parse(options: ClangParserOptions, logger: &Logger) -> Result<Vec<Global>
     let cursor = unit.cursor();
 
     if ctx.options.emit_ast {
-        cursor.visit(|&mut: cur, _: &Cursor| ast_dump(cur, 0));
+        cursor.visit(|cur, _: &Cursor| ast_dump(cur, 0));
     }
 
-    cursor.visit(|&mut: cur, _: &Cursor| visit_top(cur, &mut ctx));
+    cursor.visit(|cur, _: &Cursor| visit_top(cur, &mut ctx));
 
     while !ctx.builtin_defs.is_empty() {
         let c = ctx.builtin_defs.remove(0);


### PR DESCRIPTION
On Fedora machines (and I believe CentOS and RHEL too), `libclang.so` is stored either on `/usr/lib/llvm` on `/usr/lib64/llvm`, depending on whether the system is 64 bits or not.

This PR changes the build script to also search for `libclang.so` on these directories, making it possible to build `rust-bindgen` on fedora without setting any environment variables.

This PR is based on top of #174, because I couldn't build on the current Rust otherwise. Let me know if I should rebase back to bindgen master.