### PR TITLE
Link to LLVM/clang statically

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -30,9 +30,57 @@ fn main() {
         }
     }).next();
 
+    macro_rules! qw {
+        ($($i:ident)*) => (vec!($(stringify!($i)),*));
+    }
 
     if let Some(clang_dir) = maybe_clang_dir {
-        println!("cargo:rustc-flags=-l clang -L {}", clang_dir.as_str().unwrap());
+        let libs = qw![
+            LLVMAnalysis
+            LLVMBitReader
+            LLVMCore
+            LLVMLTO
+            LLVMLinker
+            LLVMMC
+            LLVMMCParser
+            LLVMObjCARCOpts
+            LLVMObject
+            LLVMOption
+            LLVMScalarOpts
+            LLVMSupport
+            LLVMTarget
+            LLVMTransformUtils
+            LLVMVectorize
+            LLVMipa
+            LLVMipo
+            clang
+            clangARCMigrate
+            clangAST
+            clangASTMatchers
+            clangAnalysis
+            clangBasic
+            clangDriver
+            clangEdit
+            clangFormat
+            clangFrontend
+            clangIndex
+            clangLex
+            clangParse
+            clangRewrite
+            clangRewriteFrontend
+            clangSema
+            clangSerialization
+            clangStaticAnalyzerCheckers
+            clangStaticAnalyzerCore
+            clangStaticAnalyzerFrontend
+            clangTooling
+        ];
+
+        print!("cargo:rustc-flags=");
+        for lib in libs {
+            print!("-l static={} ", lib);
+        }
+        println!("-L {} -l ncursesw -l z -l stdc++", clang_dir.as_str().unwrap());
     } else {
         panic!("Unable to find {}", clang_lib);
     }

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -8,7 +8,6 @@ use std::str;
 use std::ffi;
 use std::hash::Hash;
 use std::hash::Hasher;
-use std::hash::Writer;
 use std::ffi::CString;
 
 pub use clangll as ll;
@@ -154,8 +153,8 @@ impl PartialEq for Cursor {
 
 impl Eq for Cursor {}
 
-impl<S: Writer + Hasher> Hash<S> for Cursor {
-    fn hash(&self, state: &mut S) {
+impl Hash for Cursor {
+    fn hash<S: Hasher>(&self, state: &mut S) {
         self.x.kind.hash(state);
         self.x.xdata.hash(state);
         self.x.data[0].hash(state);
@@ -462,7 +461,7 @@ impl UnsavedFile {
         let x = Struct_CXUnsavedFile {
             Filename: name.as_ptr(),
             Contents: contents.as_ptr(),
-            Length: contents.len() as c_ulong,
+            Length: contents.as_bytes().len() as c_ulong,
         };
         UnsavedFile {
             x: x,

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -13,6 +13,7 @@ use syntax::codemap::{Span, Spanned, respan, ExpnInfo, NameAndSpan, MacroBang};
 use syntax::ext::base;
 use syntax::ext::build::AstBuilder;
 use syntax::ext::expand::ExpansionConfig;
+use syntax::feature_gate::Features;
 use syntax::owned_slice::OwnedSlice;
 use syntax::parse;
 use syntax::attr::mk_attr_id;
@@ -115,10 +116,15 @@ fn enum_name(name: &String) -> String {
 
 pub fn gen_mod(links: &[(String, LinkType)], globs: Vec<Global>, span: Span) -> Vec<P<ast::Item>> {
     // Create a dummy ExtCtxt. We only need this for string interning and that uses TLS.
+    let features = Features {
+        allow_quote: true,
+        ..Features::new()
+    };
+
     let cfg = ExpansionConfig {
         crate_name: "xxx".to_string(),
-        enable_quotes: true,
         recursion_limit: 64,
+        features: Some(&features),
     };
     let sess = &parse::new_parse_sess();
     let mut ctx = GenCtx {


### PR DESCRIPTION
This assumes the system clang is 3.5; would be glad to tweak this to support 3.4 as well.  Fixes #89.