### PR TITLE
fix: update to rust nightly

### DIFF
--- a/src/bgmacro.rs
+++ b/src/bgmacro.rs
@@ -1,5 +1,6 @@
 use std::default::Default;
 use std::env;
+use std::path::Path;
 
 use syntax::ast;
 use syntax::codemap;
@@ -28,7 +29,8 @@ pub fn bindgen_macro(cx: &mut base::ExtCtxt, sp: codemap::Span, tts: &[ast::Toke
 
     // Set the working dir to the directory containing the invoking rs file so
     // that clang searches for headers relative to it rather than the crate root
-    let mod_dir = Path::new(cx.codemap().span_to_filename(sp)).dirname().to_vec();
+    let filename = cx.codemap().span_to_filename(sp);
+    let mod_dir = Path::new(&filename).parent().unwrap();
     let cwd = match env::current_dir() {
       Ok(d)   => d,
       Err(e)  => panic!("Invalid current working directory: {}", e),
@@ -52,7 +54,7 @@ pub fn bindgen_macro(cx: &mut base::ExtCtxt, sp: codemap::Span, tts: &[ast::Toke
         Err(_) => base::DummyResult::any(sp)
     };
 
-    let p = Path::new(cwd);
+    let p = Path::new(&cwd);
     if let Err(e) = env::set_current_dir(&p) {
       panic!("Failed to return to directory {}: {}", p.display(), e);
     }

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -708,7 +708,7 @@ pub fn ast_dump(c: &Cursor, depth: isize)-> Enum_CXVisitorResult {
         c.spelling().as_slice(),
         type_to_str(ct)).as_slice()
     );
-    c.visit(|&: s, _: &Cursor| {
+    c.visit(| s, _: &Cursor| {
         ast_dump(s, depth + 1)
     });
     print_indent(depth, ")");

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -681,7 +681,7 @@ fn gen_comp_methods(ctx: &mut GenCtx, data_field: &str, data_offset: usize,
                     extra: &mut Vec<P<ast::Item>>) -> Vec<ast::ImplItem> {
     let data_ident = ctx.ext_cx.ident_of(data_field);
 
-    let mk_field_method = |&: ctx: &mut GenCtx, f: &FieldInfo, offset: usize| {
+    let mk_field_method = |ctx: &mut GenCtx, f: &FieldInfo, offset: usize| {
         // TODO: Implement bitfield accessors
         if f.bitfields.is_some() { return None; }
 
@@ -984,6 +984,7 @@ fn cty_to_rs(ctx: &mut GenCtx, ty: &Type) -> ast::Ty {
 
 fn mk_ty(ctx: &GenCtx, global: bool, segments: Vec<String>) -> ast::Ty {
     let ty = ast::TyPath(
+        None,
         ast::Path {
             span: ctx.span,
             global: global,
@@ -998,7 +999,6 @@ fn mk_ty(ctx: &GenCtx, global: bool, segments: Vec<String>) -> ast::Ty {
                 }
             }).collect()
         },
-        ast::DUMMY_NODE_ID
     );
 
     return ast::Ty {
@@ -1100,12 +1100,12 @@ fn mk_fnty(ctx: &mut GenCtx, decl: &ast::FnDecl, abi: abi::Abi) -> ast::Ty {
     return ast::Ty {
         id: ast::DUMMY_NODE_ID,
         node: ast::TyPath(
+            None,
             ast::Path {
                 span: ctx.span,
                 global: true,
                 segments: segs
             },
-            ast::DUMMY_NODE_ID
         ),
         span: ctx.span
     };


### PR DESCRIPTION
Passes `cargo build`, and I can use it to generate `termios.rs` bindings (forcing static linking the libclang)