### PR TITLE
add a cargo feature to statically link to libclang

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ license = "BSD-3-Clause"
 
 build = "build.rs"
 
+[features]
+static = []
+
 [lib]
 
 name = "bindgen"

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ const LINUX_CLANG_DIRS: &'static [&'static str] = &["/usr/lib", "/usr/lib/llvm",
 const MAC_CLANG_DIR: &'static str = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
 
 fn main() {
-    let use_static_lib = env::var_os("LIBCLANG_STATIC").is_some();
+    let use_static_lib = env::var_os("LIBCLANG_STATIC").is_some() || cfg!(feature = "static");
 
     let possible_clang_dirs = if let Ok(dir) = env::var("LIBCLANG_PATH") {
         vec![dir]

--- a/src/bgmacro.rs
+++ b/src/bgmacro.rs
@@ -1,5 +1,6 @@
 use std::default::Default;
 use std::env;
+use std::path::Path;
 
 use syntax::ast;
 use syntax::codemap;
@@ -28,7 +29,8 @@ pub fn bindgen_macro(cx: &mut base::ExtCtxt, sp: codemap::Span, tts: &[ast::Toke
 
     // Set the working dir to the directory containing the invoking rs file so
     // that clang searches for headers relative to it rather than the crate root
-    let mod_dir = Path::new(cx.codemap().span_to_filename(sp)).dirname().to_vec();
+    let filename = cx.codemap().span_to_filename(sp);
+    let mod_dir = Path::new(&filename).parent().unwrap();
     let cwd = match env::current_dir() {
       Ok(d)   => d,
       Err(e)  => panic!("Invalid current working directory: {}", e),
@@ -52,7 +54,7 @@ pub fn bindgen_macro(cx: &mut base::ExtCtxt, sp: codemap::Span, tts: &[ast::Toke
         Err(_) => base::DummyResult::any(sp)
     };
 
-    let p = Path::new(cwd);
+    let p = Path::new(&cwd);
     if let Err(e) = env::set_current_dir(&p) {
       panic!("Failed to return to directory {}: {}", p.display(), e);
     }

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -708,7 +708,7 @@ pub fn ast_dump(c: &Cursor, depth: isize)-> Enum_CXVisitorResult {
         c.spelling().as_slice(),
         type_to_str(ct)).as_slice()
     );
-    c.visit(|&: s, _: &Cursor| {
+    c.visit(| s, _: &Cursor| {
         ast_dump(s, depth + 1)
     });
     print_indent(depth, ")");

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -681,7 +681,7 @@ fn gen_comp_methods(ctx: &mut GenCtx, data_field: &str, data_offset: usize,
                     extra: &mut Vec<P<ast::Item>>) -> Vec<ast::ImplItem> {
     let data_ident = ctx.ext_cx.ident_of(data_field);
 
-    let mk_field_method = |&: ctx: &mut GenCtx, f: &FieldInfo, offset: usize| {
+    let mk_field_method = |ctx: &mut GenCtx, f: &FieldInfo, offset: usize| {
         // TODO: Implement bitfield accessors
         if f.bitfields.is_some() { return None; }
 
@@ -984,6 +984,7 @@ fn cty_to_rs(ctx: &mut GenCtx, ty: &Type) -> ast::Ty {
 
 fn mk_ty(ctx: &GenCtx, global: bool, segments: Vec<String>) -> ast::Ty {
     let ty = ast::TyPath(
+        None,
         ast::Path {
             span: ctx.span,
             global: global,
@@ -998,7 +999,6 @@ fn mk_ty(ctx: &GenCtx, global: bool, segments: Vec<String>) -> ast::Ty {
                 }
             }).collect()
         },
-        ast::DUMMY_NODE_ID
     );
 
     return ast::Ty {
@@ -1100,12 +1100,12 @@ fn mk_fnty(ctx: &mut GenCtx, decl: &ast::FnDecl, abi: abi::Abi) -> ast::Ty {
     return ast::Ty {
         id: ast::DUMMY_NODE_ID,
         node: ast::TyPath(
+            None,
             ast::Path {
                 span: ctx.span,
                 global: true,
                 segments: segs
             },
-            ast::DUMMY_NODE_ID
         ),
         span: ctx.span
     };


### PR DESCRIPTION
I use rust-bindgen as a build-dependency, but it only works if it was statically linked to libclang. IMO a cargo feature makes it easier to select between static and dynamic linking.

This is rebased on top of #181