### PR TITLE
fix: `impl Clone` on generated structs/enums

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -561,6 +561,7 @@ fn cstruct_to_rs(ctx: &mut GenCtx, name: String, members: Vec<CompMember>) -> Ve
                 span: ctx.span}));
     }
 
+    items.push(mk_clone_impl(ctx, &name[..]));
     items.push(mk_default_impl(ctx, &name[..]));
     items.extend(extra.into_iter());
     items
@@ -633,6 +634,7 @@ fn cunion_to_rs(ctx: &mut GenCtx, name: String, layout: Layout, members: Vec<Com
         mk_item(ctx, "".to_string(), union_impl, ast::Inherited, Vec::new())
     );
 
+    items.push(mk_clone_impl(ctx, &name[..]));
     items.push(mk_default_impl(ctx, &name[..]));
     items.extend(extra.into_iter());
     items
@@ -757,6 +759,16 @@ fn mk_default_impl(ctx: &GenCtx, ty_name: &str) -> P<ast::Item> {
     quote_item!(&ctx.ext_cx,
         impl ::std::default::Default for $name_ident {
             fn default() -> $name_ident { unsafe { ::std::mem::zeroed() } }
+        }
+    ).unwrap()
+}
+
+// Implements std::clone::Clone using dereferencing
+fn mk_clone_impl(ctx: &GenCtx, ty_name: &str) -> P<ast::Item> {
+    let name_ident = ctx.ext_cx.ident_of(ty_name);
+    quote_item!(&ctx.ext_cx,
+        impl ::std::clone::Clone for $name_ident {
+            fn clone(&self) -> $name_ident { *self }
         }
     ).unwrap()
 }


### PR DESCRIPTION
The `Copy` trait requires that the implementor is also `Clone`. Currently,
generated types have a `#[derive(Copy)]` but are missing the `Clone`
implementation.

With this patch, bindgen now adds a `Clone` implementation to each generated
struct/enum. Clone is implemented as a copy because the generated types already
have a `#[derive(Copy)]`

Sample output:

```
#[repr(C)]
#[derive(Copy)]
pub struct Struct_termios {
    pub c_iflag: tcflag_t,
    pub c_oflag: tcflag_t,
    pub c_cflag: tcflag_t,
    pub c_lflag: tcflag_t,
    pub c_line: cc_t,
    pub c_cc: [cc_t; 32usize],
    pub c_ispeed: speed_t,
    pub c_ospeed: speed_t,
}
impl ::std::clone::Clone for Struct_termios {
    fn clone(&self) -> Struct_termios { *self }
}

impl ::std::default::Default for Struct_termios {
    fn default() -> Struct_termios { unsafe { ::std::mem::zeroed() } }
}
```