### PR TITLE
Move rustc plugin out into its own crate.

### DIFF
--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -1,27 +1,21 @@
 [package]
 
-name = "rust-bindgen"
+name = "rust-bindgen-plugin"
 version = "0.13.0"
 authors = ["Jyun-Yan You <jyyou.tw@gmail.com>"]
 license = "BSD-3-Clause"
 
-build = "build.rs"
-
 [dependencies.log]
 git = "https://github.com/rust-lang/log.git"
+
+[dependencies.rust-bindgen]
+path = ".."
 
 [features]
 static = []
 
 [lib]
 
-name = "bindgen"
+name = "bindgen_plugin"
 path = "src/lib.rs"
-
-[[bin]]
-
-name = "bindgen"
-doc = false
-
-[[test]]
-name = "tests"
+plugin = true

--- a/plugin/src/bgmacro.rs
+++ b/plugin/src/bgmacro.rs
@@ -10,7 +10,7 @@ use syntax::parse::token;
 use syntax::ptr::P;
 use syntax::util::small_vector::SmallVector;
 
-use super::{Bindings, BindgenOptions, LinkType, Logger};
+use bindgen::{Bindings, BindgenOptions, LinkType, Logger};
 
 pub fn bindgen_macro(cx: &mut base::ExtCtxt, sp: codemap::Span, tts: &[ast::TokenTree]) -> Box<base::MacResult+'static> {
     let mut visit = BindgenArgsVisitor {

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -1,0 +1,17 @@
+#![crate_name = "bindgen_plugin"]
+#![crate_type = "dylib"]
+#![feature(plugin_registrar, rustc_private)]
+
+extern crate bindgen;
+extern crate rustc;
+extern crate syntax;
+
+mod bgmacro;
+
+use rustc::plugin::Registry;
+
+#[doc(hidden)]
+#[plugin_registrar]
+pub fn plugin_registrar(reg: &mut Registry) {
+    reg.register_macro("bindgen", bgmacro::bindgen_macro);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 #![crate_name = "bindgen"]
 #![crate_type = "dylib"]
-#![feature(quote, plugin_registrar, unboxed_closures, rustc_private, libc, core)]
+#![feature(quote, rustc_private, libc, core)]
 
 extern crate syntax;
-extern crate rustc;
 extern crate libc;
 #[macro_use] extern crate log;
 
@@ -16,7 +15,6 @@ use syntax::codemap::{DUMMY_SP, Span};
 use syntax::print::{pp, pprust};
 use syntax::print::pp::eof;
 use syntax::ptr::P;
-use rustc::plugin::Registry;
 
 use types::Global;
 
@@ -25,13 +23,6 @@ mod clangll;
 mod clang;
 mod gen;
 mod parser;
-mod bgmacro;
-
-#[doc(hidden)]
-#[plugin_registrar]
-pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_macro("bindgen", bgmacro::bindgen_macro);
-}
 
 pub struct BindgenOptions {
     pub match_pat: Vec<String>,


### PR DESCRIPTION
This is a workaround while #89 is still breaking bindgen for many people.
I haven't tested if the plugin still works, as it always crashed for me
because of that bug.