### PR TITLE
rustup: add required trace_mac when declaring ExpansionCfg

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -119,6 +119,7 @@ pub fn gen_mod(links: &[(String, LinkType)], globs: Vec<Global>, span: Span) -> 
         crate_name: "xxx".to_string(),
         features: Some(&features),
         recursion_limit: 64,
+        trace_mac: false,
     };
     let sess = &parse::new_parse_sess();
     let mut ctx = GenCtx {


### PR DESCRIPTION
This was tested on rustc 1.0.0-dev (f46c4e158 2015-04-20) (built 2015-04-20).
The commit in rust that appears to have introduced the problem is
https://github.com/rust-lang/rust/commit/d14109ec7e90f42a7cb966415b96094b146d3706

This change will likely break with older versions of rust (e.g. 1.0 beta),
so it may be worth sitting on its inclusion into master for some
time.