### PR TITLE
Add architecture triples for Ubuntu and Debian based Linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fs;
 use std::path::Path;
 
-const LINUX_CLANG_DIRS: &'static [&'static str] = &["/usr/lib", "/usr/lib/llvm", "/usr/lib64/llvm"];
+const LINUX_CLANG_DIRS: &'static [&'static str] = &["/usr/lib", "/usr/lib/llvm", "/usr/lib64/llvm", "/usr/lib/x86_64-linux-gnu"];
 const MAC_CLANG_DIR: &'static str = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
 
 fn path_exists(path: &Path) -> bool {


### PR DESCRIPTION
ref #202.

In Ubuntu and Debian based Linux, `libclang.so` is placed in `/usr/lib/x86_64-linux-gnu`.

These Linux distributions does not put `libclang.so` to `/usr/lib`, `/usr/lib/llvm` and `/usr/lib64/llvm`.

```bash
% locate libclang.so
/usr/lib/llvm-3.4/lib/libclang.so
/usr/lib/llvm-3.4/lib/libclang.so.1
/usr/lib/x86_64-linux-gnu/libclang.so
/usr/lib/x86_64-linux-gnu/libclang.so.1
```

After this change, `cargo build` succeeded without specifying environment variables in Ubuntu 14.04.2 LTS.

```log
% cargo build
   Compiling bindgen v0.14.0 (file:///home/cosmo/Github/rust-bindgen)
   Compiling bitflags v0.1.1
   Compiling libc v0.1.6
   Compiling unicode-xid v0.0.1
   Compiling term v0.2.7
   Compiling rustc-serialize v0.3.14
   Compiling syntex_fmt_macros v0.4.2
   Compiling log v0.3.1
   Compiling syntex_syntax v0.4.2
```

```log
% ./target/debug/bindgen --help
Usage: ./target/debug/bindgen [options] input.h
Options:
    -h or --help               Display help message
    -l <name> or -l<name>      Link to a dynamic library, can be proivded
                               multiple times
    -static-link <name>        Link to a static library
    -framework-link <name>     Link to a framework
    -o <output.rs>             Write bindings to <output.rs> (default stdout)
    -match <name>              Only output bindings for definitions from files
                               whose name contains <name>
                               If multiple -match options are provided, files
                               matching any rule are bound to.
    -builtins                  Output bindings for builtin definitions
                               (for example __builtin_va_list)
    -allow-unknown-types       Don't fail if we encounter types we do not support,
                               instead treat them as void
    -emit-clang-ast            Output the ast (for debugging purposes)
    -override-enum-type <type> Override enum type, type name could be
                                 uchar
                                 schar
                                 ushort
                                 sshort
                                 uint
                                 sint
                                 ulong
                                 slong
                                 ulonglong
                                 slonglong

    Options other than stated above are passed to clang.
```