### PR TITLE
Add Debian/Ubuntu locations to clang search paths

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,15 @@ use std::env;
 use std::fs;
 use std::path::Path;
 
-const LINUX_CLANG_DIRS: &'static [&'static str] = &["/usr/lib", "/usr/lib/llvm", "/usr/lib64/llvm", "/usr/lib/x86_64-linux-gnu"];
+const LINUX_CLANG_DIRS: &'static [&'static str] = &[
+    "/usr/lib",
+    "/usr/lib/llvm",
+    "/usr/lib/llvm-3.4/lib",
+    "/usr/lib/llvm-3.5/lib",
+    "/usr/lib/llvm-3.6/lib",
+    "/usr/lib64/llvm",
+    "/usr/lib/x86_64-linux-gnu",
+];
 const MAC_CLANG_DIR: &'static str = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
 const WIN_CLANG_DIRS: &'static [&'static str] = &["C:\\Program Files\\LLVM\\bin", "C:\\Program Files\\LLVM\\lib"];
 


### PR DESCRIPTION
On Debian/Ubuntu-like systems, `libclang.so` is provided by `libclang-dev` (or versioned alternatives, like `libclang-3.4-dev`), and is found only in versioned directories. This is a relatively cheesy fix, but simple and convenient.

Fixes crabtw/rust-bindgen#202 without the ick, fixes crabtw/rust-bindgen#203, and probably fixes crabtw/rust-bindgen#189.