### PR TITLE
Add support for generating consts for integer constants. Fixes #145.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -281,6 +281,8 @@ impl fmt::Debug for TypeInfo {
 pub struct VarInfo {
     pub name: String,
     pub ty: Type,
+    //TODO: support non-integer constants
+    pub val: Option<i64>,
     pub is_const: bool
 }
 
@@ -289,6 +291,7 @@ impl VarInfo {
         VarInfo {
             name: name,
             ty: ty,
+            val: None,
             is_const: false
         }
     }


### PR DESCRIPTION
This patch adds a few things to enable this:
* Cursor::extent
* struct Token
* TranslationUnit::tokens
  - clang's C API doesn't have a straightforward way to get the integer
    literal from a variable declaration, so I used clang_tokenize to
    get the literal token and parse it.

* VarInfo::val - to store the value.

Non-const variable declarations and non-integer constants are handled as
they were previously.