### PR TITLE
Use parser.check(&token::Eof) rather than .eat().

### DIFF
--- a/bindgen_plugin/src/bgmacro.rs
+++ b/bindgen_plugin/src/bgmacro.rs
@@ -205,7 +205,7 @@ fn parse_macro_opts(cx: &mut base::ExtCtxt, tts: &[ast::TokenTree], visit: &mut 
             }
         }
 
-        if parser.eat(&token::Eof).is_ok() {
+        if parser.check(&token::Eof) {
             return args_good
         }
 


### PR DESCRIPTION
.eat() will eat a token at *any* position in the input, and there's always an EOF,
so the loop that was meant to loop over all the arguments was instead always terminating
after the first one.

parser.check(&token::Eof) returns true iff the *next* token is EOF, which is what we want.