### PR TITLE
Add support for packed attribute

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -663,6 +663,7 @@ pub fn kind_to_str(x: Enum_CXCursorKind) -> &'static str {
         CXCursor_InclusionDirective => "InclusionDirective",
         //CXCursor_FirstPreprocessing => "FirstPreprocessing",
         //CXCursor_LastPreprocessing => "LastPreprocessing",
+        CXCursor_PackedAttr => "PackedAttr",
 
         _ => "?",
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -128,15 +128,16 @@ impl Type {
 pub struct Layout {
     pub size: usize,
     pub align: usize,
+    pub packed: bool,
 }
 
 impl Layout {
     pub fn new(size: usize, align: usize) -> Layout {
-        Layout { size: size, align: align }
+        Layout { size: size, align: align, packed: false }
     }
 
     pub fn zero() -> Layout {
-        Layout { size: 0, align: 0 }
+        Layout { size: 0, align: 0, packed: false }
     }
 }
 

--- a/tests/headers/struct_with_packing.h
+++ b/tests/headers/struct_with_packing.h
@@ -1,0 +1,4 @@
+struct a {
+    char b;
+    short c;
+} __attribute__((packed));

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -331,3 +331,22 @@ fn with_fwd_decl_struct() {
     ");
 }
 
+
+#[test]
+fn packed_struct() {
+    assert_bind_eq("headers/struct_with_packing.h", "
+        #[repr(C, packed)]
+        #[derive(Copy)]
+        pub struct Struct_a {
+            pub b: ::libc::c_char,
+            pub c: ::libc::c_short,
+        }
+        impl ::std::clone::Clone for Struct_a {
+            fn clone(&self) -> Self { *self }
+        }
+        impl ::std::default::Default for Struct_a {
+            fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+        }
+    ");
+}
+


### PR DESCRIPTION
I have lately been toying with the Linux DVB API, and have used rust-bindgen to ease the use of the C API headers. It took me a while to realize I couldn't pass an array of structs properly when making a ioctl call, because the struct has __attribute__((packed)) as defined in the Linux headers while the Rust equivalent lacked repr(packed). Adding it fixed the problem, but of course it would be nice to not have to touch bindgen-generated source.

Clang luckily already supports the (originally GCC specific, if not counting clang) attribute. Getting the corresponding Rust struct definitions to have repr(C, packed) wasn't terribly difficult, so here I present this PR. However, I wouldn't say I'm very well versed in C nor (lib)clang - or rust-bindgen itself - so it is still very much possible I have overlooked something, or taken messier approach than what would be necessary.

The attribute is mediated from the parsing side to the code-generating side via a new bool field in the types::Layout struct, which I though would be approapriate place for it. Large part of the diff is just to make sure the layout gets passed over to the necessary places.