### PR TITLE
Add bundled Clang includes in default options

### DIFF
--- a/src/bin/bindgen.rs
+++ b/src/bin/bindgen.rs
@@ -162,14 +162,6 @@ pub fn main() {
     let mut bind_args: Vec<_> = env::args().collect();
     let bin = bind_args.remove(0);
 
-    match bindgen::get_include_dir() {
-        Some(path) => {
-            bind_args.push("-I".to_owned());
-            bind_args.push(path);
-        }
-        None => (),
-    }
-
     match parse_args(&bind_args[..]) {
         ParseResult::ParseErr(e) => panic!(e),
         ParseResult::CmdUsage => print_usage(bin),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,10 @@ impl Default for BindgenOptions {
             emit_ast: false,
             fail_on_unknown_type: false,
             override_enum_ty: "".to_string(),
-            clang_args: Vec::new()
+            clang_args: match get_include_dir() {
+                Some(path) => vec!("-idirafter".to_owned(), path),
+                None => Vec::new()
+            }
         }
     }
 }


### PR DESCRIPTION
This ensures that Clang always can find its bundled libraries. Without the patch it's not true for library invocations, only for the bundled utility. One example is that on NixOS, where headers are located in non-standard directory, tests will fail.

This also uses second include path, allowing one to override it if wanted.