### PR TITLE
Translate C enums to Rust enums

### DIFF
--- a/tests/headers/enum.h
+++ b/tests/headers/enum.h
@@ -1,0 +1,9 @@
+enum Foo {
+    Bar = 0,
+    Qux
+};
+
+enum Neg {
+    MinusOne = -1,
+    One = 1,
+};

--- a/tests/headers/enum_dupe.h
+++ b/tests/headers/enum_dupe.h
@@ -1,0 +1,4 @@
+enum Foo {
+    Bar = 1,
+    Dupe = 1
+};

--- a/tests/headers/enum_explicit_type.hpp
+++ b/tests/headers/enum_explicit_type.hpp
@@ -1,0 +1,14 @@
+enum Foo: unsigned char {
+    Bar = 0,
+    Qux
+};
+
+enum Neg: char {
+    MinusOne = -1,
+    One = 1,
+};
+
+enum Bigger: unsigned short {
+    Much = 255,
+    Larger
+};

--- a/tests/headers/enum_negative.h
+++ b/tests/headers/enum_negative.h
@@ -1,0 +1,4 @@
+enum Foo {
+    Bar = -2,
+    Qux = 1,
+};

--- a/tests/headers/enum_packed.h
+++ b/tests/headers/enum_packed.h
@@ -1,0 +1,14 @@
+enum __attribute__((packed)) Foo {
+    Bar = 0,
+    Qux
+};
+
+enum __attribute__((packed)) Neg {
+    MinusOne = -1,
+    One = 1,
+};
+
+enum __attribute__((packed)) Bigger {
+    Much = 255,
+    Larger
+};

--- a/tests/support.rs
+++ b/tests/support.rs
@@ -25,6 +25,9 @@ impl Logger for TestLogger {
 
 pub fn generate_bindings(filename: &str) -> Result<Vec<P<ast::Item>>, ()> {
     let mut options:BindgenOptions = Default::default();
+    if filename.ends_with("hpp") {
+        options.clang_args.push("-std=c++11".to_string());
+    }
     options.clang_args.push(filename.to_string());
 
     let logger = TestLogger;

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -1,0 +1,53 @@
+use support::assert_bind_eq;
+
+#[test]
+fn with_simple_enum() {
+    assert_bind_eq("headers/enum.h", "
+        #[derive(Clone, Copy)]
+        #[repr(u32)]
+        pub enum Enum_Foo { Bar = 0, Qux = 1, }
+        #[derive(Clone, Copy)]
+        #[repr(i32)]
+        pub enum Enum_Neg { MinusOne = -1, One = 1, }
+    ");
+}
+
+#[test]
+fn with_packed_enums() {
+    assert_bind_eq("headers/enum_packed.h", "
+        #[derive(Clone, Copy)]
+        #[repr(u8)]
+        pub enum Enum_Foo { Bar = 0, Qux = 1, }
+        #[derive(Clone, Copy)]
+        #[repr(i8)]
+        pub enum Enum_Neg { MinusOne = -1, One = 1, }
+        #[derive(Clone, Copy)]
+        #[repr(u16)]
+        pub enum Enum_Bigger { Much = 255, Larger = 256, }
+    ");
+}
+
+#[test]
+fn with_duplicate_enum_value() {
+    assert_bind_eq("headers/enum_dupe.h", "
+        pub const Dupe: Enum_Foo = Enum_Foo::Bar;
+        #[derive(Clone, Copy)]
+        #[repr(u32)]
+        pub enum Enum_Foo { Bar = 1, }
+    ");
+}
+
+#[test]
+fn with_explicitly_typed_cxx_enum() {
+    assert_bind_eq("headers/enum_explicit_type.hpp", "
+        #[derive(Clone, Copy)]
+        #[repr(u8)]
+        pub enum Enum_Foo { Bar = 0, Qux = 1, }
+        #[derive(Clone, Copy)]
+        #[repr(i8)]
+        pub enum Enum_Neg { MinusOne = -1, One = 1, }
+        #[derive(Clone, Copy)]
+        #[repr(u16)]
+        pub enum Enum_Bigger { Much = 255, Larger = 256, }
+    ");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -8,6 +8,7 @@ mod support;
 
 // Unused until we can generate code for tests
 //mod test_cmath;
+mod test_enum;
 mod test_decl;
 mod test_func;
 mod test_struct;


### PR DESCRIPTION
Duplicate values end up as constants of the same enum type. Most enums
are repr(u32) as they should, except for those with attribute((packed)),
which are of the smallest representation possible.