### PR TITLE
Recurse into unexposed decls

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -498,6 +498,9 @@ fn visit_top<'r>(cursor: &Cursor,
     }
 
     match cursor.kind() {
+        CXCursor_UnexposedDecl => {
+            return CXChildVisit_Recurse;
+        }
         CXCursor_StructDecl | CXCursor_UnionDecl => {
             fwd_decl(ctx, cursor, |ctx_| {
                 let decl = decl_name(ctx_, cursor);

--- a/tests/headers/extern.hpp
+++ b/tests/headers/extern.hpp
@@ -1,0 +1,3 @@
+extern "C" {
+#include "func_proto.h"
+}

--- a/tests/support.rs
+++ b/tests/support.rs
@@ -25,6 +25,9 @@ impl Logger for TestLogger {
 
 pub fn generate_bindings(filename: &str) -> Result<Vec<P<ast::Item>>, ()> {
     let mut options:BindgenOptions = Default::default();
+    if filename.ends_with("hpp") {
+        options.clang_args.push("-std=c++11".to_string());
+    }
     options.clang_args.push(filename.to_string());
 
     let logger = TestLogger;

--- a/tests/test_extern.rs
+++ b/tests/test_extern.rs
@@ -1,0 +1,8 @@
+use support::assert_bind_eq;
+
+#[test]
+fn extern_c_in_hpp() {
+    assert_bind_eq("headers/extern.hpp", "
+        pub type foo = extern \"C\" fn(bar: ::libc::c_int) -> ::libc::c_int;
+    ");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -9,6 +9,7 @@ mod support;
 // Unused until we can generate code for tests
 //mod test_cmath;
 mod test_decl;
+mod test_extern;
 mod test_func;
 mod test_struct;
 mod test_union;


### PR DESCRIPTION
This fixes functions that use extern "C".