### PR TITLE
make get_clang_dir more robust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ fn get_clang_dir() -> Option<path::PathBuf>{
                         .file_name()
                         .and_then(|f| f.to_str())
                         .iter()
-                        .any(|&f| f == "clang") {
+                        .any(|&f| f.starts_with("clang")) {
                     if let Some(dir) = real_path.parent() {
                         return Some(dir.to_path_buf())
                     }


### PR DESCRIPTION
Similar to #242. In my system, clang is a symlink to a versioned clang (e.g.
clang-3.7), and this equality check to "clang" was failing.

This patch makes the check more robust so it can match "clang" or "clang-3.7",
but still reject a symlink to ccache.