### PR TITLE
use std::os::raw types instead of libc's

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -1031,8 +1031,15 @@ fn cfunc_to_rs(ctx: &mut GenCtx, name: String, rty: &Type,
 }
 
 fn cty_to_rs(ctx: &mut GenCtx, ty: &Type) -> ast::Ty {
+    let prefix = vec!["std".to_string(), "os".to_string(), "raw".to_string()];
+    let raw = |fragment: &str| {
+        let mut path = prefix.clone();
+        path.push(fragment.to_string());
+        path
+    };
+
     return match ty {
-        &TVoid => mk_ty(ctx, true, vec!("libc".to_string(), "c_void".to_string())),
+        &TVoid => mk_ty(ctx, true, raw("c_void")),
         &TInt(i, ref layout) => match i {
             IBool => {
                 let ty_name = match layout.size {
@@ -1044,20 +1051,20 @@ fn cty_to_rs(ctx: &mut GenCtx, ty: &Type) -> ast::Ty {
                 };
                 mk_ty(ctx, false, vec!(ty_name.to_string()))
             },
-            ISChar => mk_ty(ctx, true, vec!("libc".to_string(), "c_char".to_string())),
-            IUChar => mk_ty(ctx, true, vec!("libc".to_string(), "c_uchar".to_string())),
-            IInt => mk_ty(ctx, true, vec!("libc".to_string(), "c_int".to_string())),
-            IUInt => mk_ty(ctx, true, vec!("libc".to_string(), "c_uint".to_string())),
-            IShort => mk_ty(ctx, true, vec!("libc".to_string(), "c_short".to_string())),
-            IUShort => mk_ty(ctx, true, vec!("libc".to_string(), "c_ushort".to_string())),
-            ILong => mk_ty(ctx, true, vec!("libc".to_string(), "c_long".to_string())),
-            IULong => mk_ty(ctx, true, vec!("libc".to_string(), "c_ulong".to_string())),
-            ILongLong => mk_ty(ctx, true, vec!("libc".to_string(), "c_longlong".to_string())),
-            IULongLong => mk_ty(ctx, true, vec!("libc".to_string(), "c_ulonglong".to_string()))
+            ISChar => mk_ty(ctx, true, raw("c_char")),
+            IUChar => mk_ty(ctx, true, raw("c_uchar")),
+            IInt => mk_ty(ctx, true, raw("c_int")),
+            IUInt => mk_ty(ctx, true, raw("c_uint")),
+            IShort => mk_ty(ctx, true, raw("c_short")),
+            IUShort => mk_ty(ctx, true, raw("c_ushort")),
+            ILong => mk_ty(ctx, true, raw("c_long")),
+            IULong => mk_ty(ctx, true, raw("c_ulong")),
+            ILongLong => mk_ty(ctx, true, raw("c_longlong")),
+            IULongLong => mk_ty(ctx, true, raw("c_ulonglong"))
         },
         &TFloat(f, _) => match f {
-            FFloat => mk_ty(ctx, true, vec!("libc".to_string(), "c_float".to_string())),
-            FDouble => mk_ty(ctx, true, vec!("libc".to_string(), "c_double".to_string()))
+            FFloat => mk_ty(ctx, true, raw("c_float")),
+            FDouble => mk_ty(ctx, true, raw("c_double"))
         },
         &TPtr(ref t, is_const, _) => {
             let id = cty_to_rs(ctx, &**t);

--- a/tests/test_decl.rs
+++ b/tests/test_decl.rs
@@ -4,7 +4,7 @@ use support::assert_bind_eq;
 fn ptr_to_array() {
     assert_bind_eq("headers/decl_ptr_to_array.h", "
         extern \"C\" {
-            pub static mut foo: [::libc::c_int; 1usize];
+            pub static mut foo: [::std::os::raw::c_int; 1usize];
         }
     ");
 }

--- a/tests/test_extern.rs
+++ b/tests/test_extern.rs
@@ -3,6 +3,6 @@ use support::assert_bind_eq;
 #[test]
 fn extern_c_in_hpp() {
     assert_bind_eq("headers/extern.hpp", "
-        pub type foo = extern \"C\" fn(bar: ::libc::c_int) -> ::libc::c_int;
+        pub type foo = extern \"C\" fn(bar: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
     ");
 }

--- a/tests/test_func.rs
+++ b/tests/test_func.rs
@@ -5,8 +5,8 @@ fn func_ptr() {
     assert_bind_eq("headers/func_ptr.h", "
         extern \"C\" {
             pub static mut foo: ::std::option::Option<
-                extern \"C\" fn(x: ::libc::c_int,
-                              y: ::libc::c_int) -> ::libc::c_int>;
+                extern \"C\" fn(x: ::std::os::raw::c_int,
+                              y: ::std::os::raw::c_int) -> ::std::os::raw::c_int>;
         }
     ");
 }
@@ -18,8 +18,8 @@ fn func_ptr_in_struct() {
         #[derive(Copy)]
         pub struct Struct_Foo {
             pub bar: ::std::option::Option<
-                extern \"C\" fn(x: ::libc::c_int,
-                              y: ::libc::c_int) -> Enum_baz>,
+                extern \"C\" fn(x: ::std::os::raw::c_int,
+                              y: ::std::os::raw::c_int) -> Enum_baz>,
         }
 
         impl ::std::clone::Clone for Struct_Foo {
@@ -35,7 +35,7 @@ fn func_ptr_in_struct() {
 #[test]
 fn func_proto() {
     assert_bind_eq("headers/func_proto.h", "
-        pub type foo = extern \"C\" fn(bar: ::libc::c_int) -> ::libc::c_int;
+        pub type foo = extern \"C\" fn(bar: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
     ");
 }
 
@@ -52,7 +52,7 @@ fn with_func_ptr_arg() {
 fn with_array_arg() {
     assert_bind_eq("headers/func_with_array_arg.h", "
         extern \"C\" {
-            pub fn f(x: *mut ::libc::c_int);
+            pub fn f(x: *mut ::std::os::raw::c_int);
         }
     ");
 }

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -17,8 +17,8 @@ fn with_anon_struct() {
         #[repr(C)]
         #[derive(Copy)]
         pub struct Struct_Unnamed1 {
-            pub a: ::libc::c_int,
-            pub b: ::libc::c_int,
+            pub a: ::std::os::raw::c_int,
+            pub b: ::std::os::raw::c_int,
         }
         impl ::std::clone::Clone for Struct_Unnamed1 {
             fn clone(&self) -> Self { *self }
@@ -50,8 +50,8 @@ fn with_anon_struct_array() {
         #[repr(C)]
         #[derive(Copy)]
         pub struct Struct_Unnamed1 {
-            pub a: ::libc::c_int,
-            pub b: ::libc::c_int,
+            pub a: ::std::os::raw::c_int,
+            pub b: ::std::os::raw::c_int,
         }
 
         impl ::std::clone::Clone for Struct_Unnamed1 {
@@ -65,8 +65,8 @@ fn with_anon_struct_array() {
         #[repr(C)]
         #[derive(Copy)]
         pub struct Struct_Unnamed2 {
-            pub a: ::libc::c_int,
-            pub b: ::libc::c_int,
+            pub a: ::std::os::raw::c_int,
+            pub b: ::std::os::raw::c_int,
         }
 
         impl ::std::clone::Clone for Struct_Unnamed2 {
@@ -96,8 +96,8 @@ fn with_anon_struct_pointer() {
         #[repr(C)]
         #[derive(Copy)]
         pub struct Struct_Unnamed1 {
-            pub a: ::libc::c_int,
-            pub b: ::libc::c_int,
+            pub a: ::std::os::raw::c_int,
+            pub b: ::std::os::raw::c_int,
         }
         impl ::std::clone::Clone for Struct_Unnamed1 {
             fn clone(&self) -> Self { *self }
@@ -128,11 +128,11 @@ fn with_anon_union() {
             pub _bindgen_data_: [u32; 1usize],
         }
         impl Union_Unnamed1 {
-            pub unsafe fn a(&mut self) -> *mut ::libc::c_uint {
+            pub unsafe fn a(&mut self) -> *mut ::std::os::raw::c_uint {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn b(&mut self) -> *mut ::libc::c_ushort {
+            pub unsafe fn b(&mut self) -> *mut ::std::os::raw::c_ushort {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(0))
             }
@@ -155,11 +155,11 @@ fn with_anon_unnamed_struct() {
             pub _bindgen_data_1_: [u32; 2usize],
         }
         impl Struct_foo {
-            pub unsafe fn a(&mut self) -> *mut ::libc::c_uint {
+            pub unsafe fn a(&mut self) -> *mut ::std::os::raw::c_uint {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_1_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn b(&mut self) -> *mut ::libc::c_uint {
+            pub unsafe fn b(&mut self) -> *mut ::std::os::raw::c_uint {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_1_);
                 ::std::mem::transmute(raw.offset(4))
             }
@@ -182,11 +182,11 @@ fn with_anon_unnamed_union() {
             pub _bindgen_data_1_: [u32; 1usize],
         }
         impl Struct_foo {
-            pub unsafe fn a(&mut self) -> *mut ::libc::c_uint {
+            pub unsafe fn a(&mut self) -> *mut ::std::os::raw::c_uint {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_1_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn b(&mut self) -> *mut ::libc::c_ushort {
+            pub unsafe fn b(&mut self) -> *mut ::std::os::raw::c_ushort {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_1_);
                 ::std::mem::transmute(raw.offset(0))
             }
@@ -206,35 +206,35 @@ fn with_nesting() {
         #[repr(C)]
         #[derive(Copy)]
         pub struct Struct_foo {
-            pub a: ::libc::c_uint,
+            pub a: ::std::os::raw::c_uint,
             pub _bindgen_data_1_: [u32; 1usize],
         }
         impl Struct_foo {
-            pub unsafe fn b(&mut self) -> *mut ::libc::c_uint {
+            pub unsafe fn b(&mut self) -> *mut ::std::os::raw::c_uint {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_1_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn c1(&mut self) -> *mut ::libc::c_ushort {
+            pub unsafe fn c1(&mut self) -> *mut ::std::os::raw::c_ushort {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_1_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn c2(&mut self) -> *mut ::libc::c_ushort {
+            pub unsafe fn c2(&mut self) -> *mut ::std::os::raw::c_ushort {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_1_);
                 ::std::mem::transmute(raw.offset(2))
             }
-            pub unsafe fn d1(&mut self) -> *mut ::libc::c_uchar {
+            pub unsafe fn d1(&mut self) -> *mut ::std::os::raw::c_uchar {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_1_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn d2(&mut self) -> *mut ::libc::c_uchar {
+            pub unsafe fn d2(&mut self) -> *mut ::std::os::raw::c_uchar {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_1_);
                 ::std::mem::transmute(raw.offset(1))
             }
-            pub unsafe fn d3(&mut self) -> *mut ::libc::c_uchar {
+            pub unsafe fn d3(&mut self) -> *mut ::std::os::raw::c_uchar {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_1_);
                 ::std::mem::transmute(raw.offset(2))
             }
-            pub unsafe fn d4(&mut self) -> *mut ::libc::c_uchar {
+            pub unsafe fn d4(&mut self) -> *mut ::std::os::raw::c_uchar {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_1_);
                 ::std::mem::transmute(raw.offset(3))
             }
@@ -268,7 +268,7 @@ fn containing_fwd_decl_struct() {
         #[repr(C)]
         #[derive(Copy)]
         pub struct Struct_b {
-            pub val_b: ::libc::c_int,
+            pub val_b: ::std::os::raw::c_int,
         }
 
         impl ::std::clone::Clone for Struct_b {
@@ -287,10 +287,10 @@ fn with_bitfields() {
         #[repr(C)]
         #[derive(Copy)]
         pub struct Struct_bitfield {
-            pub _bindgen_bitfield_1_: ::libc::c_ushort,
-            pub e: ::libc::c_int,
-            pub _bindgen_bitfield_2_: ::libc::c_uint,
-            pub _bindgen_bitfield_3_: ::libc::c_uint,
+            pub _bindgen_bitfield_1_: ::std::os::raw::c_ushort,
+            pub e: ::std::os::raw::c_int,
+            pub _bindgen_bitfield_2_: ::std::os::raw::c_uint,
+            pub _bindgen_bitfield_3_: ::std::os::raw::c_uint,
         }
 
         impl ::std::clone::Clone for Struct_bitfield {
@@ -309,7 +309,7 @@ fn with_fwd_decl_struct() {
         #[repr(C)]
         #[derive(Copy)]
         pub struct Struct_a {
-            pub b: ::libc::c_int,
+            pub b: ::std::os::raw::c_int,
         }
         impl ::std::clone::Clone for Struct_a {
             fn clone(&self) -> Self { *self }
@@ -320,7 +320,7 @@ fn with_fwd_decl_struct() {
         #[repr(C)]
         #[derive(Copy)]
         pub struct Struct_c {
-            pub d: ::libc::c_int,
+            pub d: ::std::os::raw::c_int,
         }
         impl ::std::clone::Clone for Struct_c {
             fn clone(&self) -> Self { *self }
@@ -338,8 +338,8 @@ fn packed_struct() {
         #[repr(C, packed)]
         #[derive(Copy)]
         pub struct Struct_a {
-            pub b: ::libc::c_char,
-            pub c: ::libc::c_short,
+            pub b: ::std::os::raw::c_char,
+            pub c: ::std::os::raw::c_short,
         }
         impl ::std::clone::Clone for Struct_a {
             fn clone(&self) -> Self { *self }

--- a/tests/test_union.rs
+++ b/tests/test_union.rs
@@ -23,8 +23,8 @@ fn with_anon_struct() {
         #[repr(C)]
         #[derive(Copy)]
         pub struct Struct_Unnamed1 {
-            pub a: ::libc::c_uint,
-            pub b: ::libc::c_uint,
+            pub a: ::std::os::raw::c_uint,
+            pub b: ::std::os::raw::c_uint,
         }
         impl ::std::clone::Clone for Struct_Unnamed1 {
             fn clone(&self) -> Self { *self }
@@ -45,7 +45,7 @@ fn with_anon_struct_bitfield() {
         }
 
         impl Union_foo {
-            pub unsafe fn a(&mut self) -> *mut ::libc::c_int {
+            pub unsafe fn a(&mut self) -> *mut ::std::os::raw::c_int {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(0))
             }
@@ -87,11 +87,11 @@ fn with_anon_union() {
             pub _bindgen_data_: [u32; 1usize],
         }
         impl Union_Unnamed1 {
-            pub unsafe fn a(&mut self) -> *mut ::libc::c_uint {
+            pub unsafe fn a(&mut self) -> *mut ::std::os::raw::c_uint {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn b(&mut self) -> *mut ::libc::c_ushort {
+            pub unsafe fn b(&mut self) -> *mut ::std::os::raw::c_ushort {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(0))
             }
@@ -114,23 +114,23 @@ fn with_anon_unnamed_struct() {
             pub _bindgen_data_: [u32; 1usize],
         }
         impl Union_pixel {
-            pub unsafe fn rgba(&mut self) -> *mut ::libc::c_uint {
+            pub unsafe fn rgba(&mut self) -> *mut ::std::os::raw::c_uint {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn r(&mut self) -> *mut ::libc::c_uchar {
+            pub unsafe fn r(&mut self) -> *mut ::std::os::raw::c_uchar {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn g(&mut self) -> *mut ::libc::c_uchar {
+            pub unsafe fn g(&mut self) -> *mut ::std::os::raw::c_uchar {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(1))
             }
-            pub unsafe fn b(&mut self) -> *mut ::libc::c_uchar {
+            pub unsafe fn b(&mut self) -> *mut ::std::os::raw::c_uchar {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(2))
             }
-            pub unsafe fn a(&mut self) -> *mut ::libc::c_uchar {
+            pub unsafe fn a(&mut self) -> *mut ::std::os::raw::c_uchar {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(3))
             }
@@ -153,15 +153,15 @@ fn with_anon_unnamed_union() {
             pub _bindgen_data_: [u32; 1usize],
         }
         impl Union_foo {
-            pub unsafe fn a(&mut self) -> *mut ::libc::c_uint {
+            pub unsafe fn a(&mut self) -> *mut ::std::os::raw::c_uint {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn b(&mut self) -> *mut ::libc::c_ushort {
+            pub unsafe fn b(&mut self) -> *mut ::std::os::raw::c_ushort {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn c(&mut self) -> *mut ::libc::c_uchar {
+            pub unsafe fn c(&mut self) -> *mut ::std::os::raw::c_uchar {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(0))
             }
@@ -184,23 +184,23 @@ fn with_nesting() {
             pub _bindgen_data_: [u32; 1usize],
         }
         impl Union_foo {
-            pub unsafe fn a(&mut self) -> *mut ::libc::c_uint {
+            pub unsafe fn a(&mut self) -> *mut ::std::os::raw::c_uint {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn b1(&mut self) -> *mut ::libc::c_ushort {
+            pub unsafe fn b1(&mut self) -> *mut ::std::os::raw::c_ushort {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn b2(&mut self) -> *mut ::libc::c_ushort {
+            pub unsafe fn b2(&mut self) -> *mut ::std::os::raw::c_ushort {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(0))
             }
-            pub unsafe fn c1(&mut self) -> *mut ::libc::c_ushort {
+            pub unsafe fn c1(&mut self) -> *mut ::std::os::raw::c_ushort {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(2))
             }
-            pub unsafe fn c2(&mut self) -> *mut ::libc::c_ushort {
+            pub unsafe fn c2(&mut self) -> *mut ::std::os::raw::c_ushort {
                 let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
                 ::std::mem::transmute(raw.offset(2))
             }


### PR DESCRIPTION
two things that occurred to me while working on this:

- Should this change land behind a BindgenOption? That way, by default, bindgen uses the libc types, and when the option is enabled bindgen uses std::os::raw types.
- This patch use the std::os::raw types, but it's also possible to use the core::os::raw types. We could add, later, a `nostd` option to BindgenOptions that let the user pick between the core or the std types.

cc @mbrubeck 