### PR TITLE
Support for inline enum declarations in struct fields

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `-no-rust-enums` generate integer constants instead of enums
 - Derive Debug when possible
+- Support for inline enum declarations in struct fields (e.g.: `struct { enum { Option_A, Option_B } field; };`)
 
 ### Changed
 - Use `clang_sys` instead of the internal ffi

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -544,20 +544,12 @@ fn cstruct_to_rs(ctx: &mut GenCtx,
 
         if let Some(rc_e) = opt_rc_e {
             let e = rc_e.borrow();
-            if e.name.is_empty() {
-                //XXX: 10.000 lines of Linux header code do not trigger this. What does it do?
-                unreachable!();
-                //unnamed += 1;
-                //let field_name = format!("_bindgen_data_{}_", unnamed);
-                //fields.push(mk_blob_field(ctx, &field_name[..], c.layout));
-                //methods.extend(gen_comp_methods(ctx, &field_name[..], 0, c.kind, &c.members, &mut extra, options, derive_debug).into_iter());
-            } else {
-                extra.extend(cenum_to_rs(
-                    ctx,
-                    options,
-                    options.derive_debug,
-                    &e.name, e.kind, e.layout, &e.items));
-            }
+            assert!(!e.name.is_empty());
+            extra.extend(cenum_to_rs(
+                ctx,
+                options,
+                options.derive_debug,
+                &e.name, e.kind, e.layout, &e.items));
         }
     }
 

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -549,7 +549,7 @@ fn cstruct_to_rs(ctx: &mut GenCtx,
                 ctx,
                 options,
                 options.derive_debug,
-                &e.name, e.kind, e.layout, &e.items));
+                &enum_name(&e.name), e.kind, e.layout, &e.items));
         }
     }
 

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -94,7 +94,7 @@ fn extract_definitions(ctx: &mut GenCtx,
                 let t = ti.borrow();
                 defs.extend(ctypedef_to_rs(
                     ctx,
-                    options.rust_enums,
+                    options,
                     options.derive_debug,
                     &t.name, &t.ty))
             },
@@ -113,7 +113,7 @@ fn extract_definitions(ctx: &mut GenCtx,
                 }
                 let c = ci.borrow().clone();
                 defs.extend(comp_to_rs(ctx, c.kind, comp_name(c.kind, &c.name),
-                                       options.derive_debug,
+                                       options, options.derive_debug,
                                        c.layout, c.members).into_iter())
             },
             GEnumDecl(ref ei) => {
@@ -132,7 +132,7 @@ fn extract_definitions(ctx: &mut GenCtx,
                 let e = ei.borrow();
                 defs.extend(cenum_to_rs(
                     ctx,
-                    options.rust_enums,
+                    options,
                     options.derive_debug,
                     &enum_name(&e.name), e.kind, e.layout, &e.items));
             },
@@ -410,7 +410,7 @@ fn tag_dup_decl(gs: &[Global]) -> Vec<Global> {
 /// Converts a C typedef to Rust AST Items.
 fn ctypedef_to_rs(
         ctx: &mut GenCtx,
-        rust_enums: bool,
+        options: &BindgenOptions,
         derive_debug: bool,
         name: &str,
         ty: &Type)
@@ -443,7 +443,7 @@ fn ctypedef_to_rs(
             if is_empty {
                 ci.borrow_mut().name = name.into();
                 let c = ci.borrow().clone();
-                comp_to_rs(ctx, c.kind, name.into(), derive_debug, c.layout, c.members)
+                comp_to_rs(ctx, c.kind, name.into(), options, derive_debug, c.layout, c.members)
             } else {
                 vec!(mk_item(ctx, name, ty))
             }
@@ -453,7 +453,7 @@ fn ctypedef_to_rs(
             if is_empty {
                 ei.borrow_mut().name = name.into();
                 let e = ei.borrow();
-                cenum_to_rs(ctx, rust_enums, derive_debug, name, e.kind, e.layout, &e.items)
+                cenum_to_rs(ctx, options, derive_debug, name, e.kind, e.layout, &e.items)
             } else {
                 vec!(mk_item(ctx, name, ty))
             }
@@ -464,17 +464,19 @@ fn ctypedef_to_rs(
 
 /// Converts a C composed type (struct or union) to Rust AST Items.
 fn comp_to_rs(ctx: &mut GenCtx, kind: CompKind, name: String,
+              options: &BindgenOptions,
               derive_debug: bool,
               layout: Layout, members: Vec<CompMember>) -> Vec<P<ast::Item>> {
     match kind {
-        CompKind::Struct => cstruct_to_rs(ctx, &name, derive_debug, layout, members),
-        CompKind::Union =>  cunion_to_rs(ctx, name, derive_debug, layout, members),
+        CompKind::Struct => cstruct_to_rs(ctx, &name, options, derive_debug, layout, members),
+        CompKind::Union =>  cunion_to_rs(ctx, name, options, derive_debug, layout, members),
     }
 }
 
 /// Converts a C struct to Rust AST Items.
 fn cstruct_to_rs(ctx: &mut GenCtx,
                  name: &str,
+                 options: &BindgenOptions,
                  derive_debug: bool,
                  layout: Layout,
                  members: Vec<CompMember>) -> Vec<P<ast::Item>> {
@@ -492,10 +494,12 @@ fn cstruct_to_rs(ctx: &mut GenCtx,
     let mut can_derive_clone = true;
 
     for m in &members {
-        let (opt_rc_c, opt_f) = match *m {
-            CompMember::Field(ref f) => { (None, Some(f)) }
-            CompMember::Comp(ref rc_c) => { (Some(rc_c), None) }
-            CompMember::CompField(ref rc_c, ref f) => { (Some(rc_c), Some(f)) }
+        let (opt_rc_c, opt_rc_e, opt_f) = match *m {
+            CompMember::Field(ref f) => { (None, None, Some(f)) }
+            CompMember::Comp(ref rc_c) => { (Some(rc_c), None, None) }
+            CompMember::CompField(ref rc_c, ref f) => { (Some(rc_c), None, Some(f)) }
+            CompMember::Enum(ref rc_e) => { (None, Some(rc_e), None) }
+            CompMember::EnumField(ref rc_e, ref f) => { (None, Some(rc_e), Some(f)) }
         };
 
         if let Some(f) = opt_f {
@@ -530,11 +534,29 @@ fn cstruct_to_rs(ctx: &mut GenCtx,
                 unnamed += 1;
                 let field_name = format!("_bindgen_data_{}_", unnamed);
                 fields.push(mk_blob_field(ctx, &field_name, c.layout, ctx.span));
-                methods.extend(gen_comp_methods(ctx, &field_name, 0, c.kind, &c.members, &mut extra, derive_debug).into_iter());
+                methods.extend(gen_comp_methods(ctx, &field_name, 0, c.kind, &c.members, &mut extra, options, derive_debug).into_iter());
             } else {
                 extra.extend(comp_to_rs(ctx, c.kind, comp_name(c.kind, &c.name),
-                                        derive_debug,
+                                        options, derive_debug,
                                         c.layout, c.members.clone()).into_iter());
+            }
+        }
+
+        if let Some(rc_e) = opt_rc_e {
+            let e = rc_e.borrow();
+            if e.name.is_empty() {
+                //XXX: 10.000 lines of Linux header code do not trigger this. What does it do?
+                unreachable!();
+                //unnamed += 1;
+                //let field_name = format!("_bindgen_data_{}_", unnamed);
+                //fields.push(mk_blob_field(ctx, &field_name[..], c.layout));
+                //methods.extend(gen_comp_methods(ctx, &field_name[..], 0, c.kind, &c.members, &mut extra, options, derive_debug).into_iter());
+            } else {
+                extra.extend(cenum_to_rs(
+                    ctx,
+                    options,
+                    options.derive_debug,
+                    &e.name, e.kind, e.layout, &e.items));
             }
         }
     }
@@ -625,7 +647,7 @@ fn opaque_to_rs(ctx: &mut GenCtx, name: &str) -> P<ast::Item> {
     })
 }
 
-fn cunion_to_rs(ctx: &mut GenCtx, name: String, derive_debug: bool, layout: Layout, members: Vec<CompMember>) -> Vec<P<ast::Item>> {
+fn cunion_to_rs(ctx: &mut GenCtx, name: String, options: &BindgenOptions, derive_debug: bool, layout: Layout, members: Vec<CompMember>) -> Vec<P<ast::Item>> {
     fn mk_item(ctx: &mut GenCtx, name: String, item: ast::ItemKind, vis:
                ast::Visibility, attrs: Vec<ast::Attribute>) -> P<ast::Item> {
         P(ast::Item {
@@ -685,7 +707,7 @@ fn cunion_to_rs(ctx: &mut GenCtx, name: String, derive_debug: bool, layout: Layo
         ast::Generics::default(),
         None,
         P(cty_to_rs(ctx, &union)),
-        gen_comp_methods(ctx, data_field_name, 0, CompKind::Union, &members, &mut extra, derive_debug),
+        gen_comp_methods(ctx, data_field_name, 0, CompKind::Union, &members, &mut extra, options, derive_debug),
     );
 
     let mut items = vec!(
@@ -779,7 +801,7 @@ fn cenum_value_to_int_lit(
 
 fn cenum_to_rs(
        ctx: &mut GenCtx,
-       rust_enums: bool,
+       options: &BindgenOptions,
        derive_debug: bool,
        name: &str,
        kind: IKind,
@@ -792,7 +814,7 @@ fn cenum_to_rs(
     let enum_repr = enum_size_to_rust_type_name(enum_is_signed, layout.size);
     let mut items = vec![];
 
-    if !rust_enums {
+    if !options.rust_enums {
         items.push(ctx.ext_cx.item_ty(
             ctx.span,
             enum_name,
@@ -875,6 +897,7 @@ fn cenum_to_rs(
 fn gen_comp_methods(ctx: &mut GenCtx, data_field: &str, data_offset: usize,
                     kind: CompKind, members: &[CompMember],
                     extra: &mut Vec<P<ast::Item>>,
+                    options: &BindgenOptions,
                     derive_debug: bool) -> Vec<ast::ImplItem> {
 
     let mk_field_method = |ctx: &mut GenCtx, f: &FieldInfo, offset: usize| {
@@ -920,7 +943,7 @@ fn gen_comp_methods(ctx: &mut GenCtx, data_field: &str, data_offset: usize,
             CompMember::Comp(ref rc_c) => {
                 let c = &rc_c.borrow();
                 methods.extend(gen_comp_methods(ctx, data_field, offset, c.kind,
-                                                &c.members, extra, derive_debug).into_iter());
+                                                &c.members, extra, options, derive_debug).into_iter());
                 c.layout.size
             }
             CompMember::CompField(ref rc_c, ref f) => {
@@ -928,8 +951,14 @@ fn gen_comp_methods(ctx: &mut GenCtx, data_field: &str, data_offset: usize,
 
                 let c = rc_c.borrow();
                 extra.extend(comp_to_rs(ctx, c.kind, comp_name(c.kind, &c.name),
-                                        derive_debug,
+                                        options, derive_debug,
                                         c.layout, c.members.clone()).into_iter());
+                f.ty.size()
+            }
+            CompMember::Enum(ref rc_e) => {
+                rc_e.borrow().layout.size
+            }
+            CompMember::EnumField(ref _rc_e, ref f) => {
                 f.ty.size()
             }
         };

--- a/src/types.rs
+++ b/src/types.rs
@@ -238,7 +238,9 @@ pub enum FKind {
 pub enum CompMember {
     Field(FieldInfo),
     Comp(Rc<RefCell<CompInfo>>),
+    Enum(Rc<RefCell<EnumInfo>>),
     CompField(Rc<RefCell<CompInfo>>, FieldInfo),
+    EnumField(Rc<RefCell<EnumInfo>>, FieldInfo),
 }
 
 /// Is the composed element a struct or an union?

--- a/tests/headers/struct_with_anon_enum.h
+++ b/tests/headers/struct_with_anon_enum.h
@@ -1,0 +1,7 @@
+struct foo {
+    enum {
+        FOO_OPTION_1,
+        FOO_OPTION_2,
+        FOO_OPTION_3
+    } bar;
+};

--- a/tests/headers/struct_with_anon_enum_bitfields.h
+++ b/tests/headers/struct_with_anon_enum_bitfields.h
@@ -1,0 +1,14 @@
+enum test {
+    TEST_OPTION_1,
+    TEST_OPTION_2,
+    TEST_OPTION_3
+};
+
+struct foo {
+    enum {
+        FOO_OPTION_1,
+        FOO_OPTION_2,
+        FOO_OPTION_3
+    } bar : 4;
+    enum test baz : 4;
+};

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -1,6 +1,53 @@
 use support::assert_bind_eq;
 
 #[test]
+fn with_anon_enum() {
+    assert_bind_eq(Default::default(), "headers/struct_with_anon_enum.h", "
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        #[derive(Debug)]
+        pub struct Struct_foo {
+            pub bar: Enum_Unnamed1,
+        }
+        impl ::std::default::Default for Struct_foo {
+            fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+        }
+        #[derive(Copy, Clone)]
+        #[repr(u32)]
+        #[derive(Debug)]
+        pub enum Unnamed1 { FOO_OPTION_1 = 0, FOO_OPTION_2 = 1, FOO_OPTION_3 = 2, }
+    ");
+}
+
+#[test]
+fn with_anon_enum_bitfields() {
+    assert_bind_eq(Default::default(), "headers/struct_with_anon_enum_bitfields.h", "
+        #[derive(Copy, Clone)]
+        #[repr(u32)]
+        #[derive(Debug)]
+        pub enum Enum_test {
+            TEST_OPTION_1 = 0,
+            TEST_OPTION_2 = 1,
+            TEST_OPTION_3 = 2,
+        }
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        #[derive(Debug)]
+        pub struct Struct_foo {
+            pub _bindgen_bitfield_1_: Enum_Unnamed1,
+            pub _bindgen_bitfield_2_: Enum_test,
+        }
+        impl ::std::default::Default for Struct_foo {
+            fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+        }
+        #[derive(Copy, Clone)]
+        #[repr(u32)]
+        #[derive(Debug)]
+        pub enum Unnamed1 { FOO_OPTION_1 = 0, FOO_OPTION_2 = 1, FOO_OPTION_3 = 2, }
+    ");
+}
+
+#[test]
 fn with_anon_struct() {
     assert_bind_eq(Default::default(), "headers/struct_with_anon_struct.h", "
         #[repr(C)]

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -15,7 +15,11 @@ fn with_anon_enum() {
         #[derive(Copy, Clone)]
         #[repr(u32)]
         #[derive(Debug)]
-        pub enum Unnamed1 { FOO_OPTION_1 = 0, FOO_OPTION_2 = 1, FOO_OPTION_3 = 2, }
+        pub enum Enum_Unnamed1 {
+            FOO_OPTION_1 = 0,
+            FOO_OPTION_2 = 1,
+            FOO_OPTION_3 = 2,
+        }
     ");
 }
 
@@ -43,7 +47,11 @@ fn with_anon_enum_bitfields() {
         #[derive(Copy, Clone)]
         #[repr(u32)]
         #[derive(Debug)]
-        pub enum Unnamed1 { FOO_OPTION_1 = 0, FOO_OPTION_2 = 1, FOO_OPTION_3 = 2, }
+        pub enum Enum_Unnamed1 {
+            FOO_OPTION_1 = 0,
+            FOO_OPTION_2 = 1,
+            FOO_OPTION_3 = 2,
+        }
     ");
 }
 


### PR DESCRIPTION
See issue #292 for details.

This also includes a small patch to `build.rs` to fix issue rust-lang/cargo#2478.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crabtw/rust-bindgen/297)
<!-- Reviewable:end -->
