### PR TITLE
Allow derive_debug to be configured & handle prefixed clang binaries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,13 @@ fn get_clang_dir() -> Option<path::PathBuf>{
                         .iter()
                         .any(|&f| f.starts_with("clang") || match env::var("TARGET") {
                             Ok(target) => {
+                                // Check if clang binary starts with the $TARGET, e.g.
+                                // x86_64-unknown-linux-gnu-clang
                                 f.starts_with(&format!("{}-clang", target)) ||
+                                // Also check the if it starts with the $TARGET after substituting
+                                // "unknown" with "pc" - some distros (Gentoo) use
+                                // x86_64-pc-linux-gnu as their $CHOST/$TARGET rather than
+                                // x86-64-unknown-linux-gnu
                                 f.starts_with(&format!("{}-clang", target.replace("unknown", "pc")))
                             }
                             _ => false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,11 @@ impl<'a> Builder<'a> {
         self
     }
 
+    pub fn derive_debug(&mut self, derive_debug: bool) -> &mut Self {
+        self.options.derive_debug = derive_debug;
+        self
+    }
+
     pub fn rust_enums(&mut self, value: bool) -> &mut Self {
         self.options.rust_enums = value;
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,13 @@ fn get_clang_dir() -> Option<path::PathBuf>{
                         .file_name()
                         .and_then(|f| f.to_str())
                         .iter()
-                        .any(|&f| f.starts_with("clang")) {
+                        .any(|&f| f.starts_with("clang") || match env::var("TARGET") {
+                            Ok(target) => {
+                                f.starts_with(&format!("{}-clang", target)) ||
+                                f.starts_with(&format!("{}-clang", target.replace("unknown", "pc")))
+                            }
+                            _ => false
+                        }) {
                     if let Some(dir) = real_path.parent() {
                         return Some(dir.to_path_buf())
                     }


### PR DESCRIPTION
Currently the derive_debug flag isn't exposed on Builder, meaning that it's always true when generating bindings through Builder. Trivial change to let this be configured.


Also, on some distributions (Gentoo for one, perhaps others), installed Clang binaries are prefixed with the CHOST/TARGET. I've made a small change to get_clang_dir to handle this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crabtw/rust-bindgen/307)
<!-- Reviewable:end -->
