### PR TITLE
Open output file with write permissions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ fn get_output(o: &str) -> Box<Write> {
     if o == "-" {
         Box::new(io::stdout())
     } else {
-        Box::new(File::open(o).expect(&format!("\"{}\" unreadable", o)))
+        Box::new(File::create(o).expect(&format!("\"{}\" unwritable", o)))
     }
 }
 


### PR DESCRIPTION
`File::open` opens the file [in read-only mode](https://doc.rust-lang.org/std/fs/struct.File.html#method.open) - which isn't very useful for an output file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crabtw/rust-bindgen/341)
<!-- Reviewable:end -->
