### PR TITLE
Bring back multiple matches support. Closes #362.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ Generate C bindings for Rust.
 
 Usage:
   bindgen [options] <file> [-- <clang-args>...]
+  bindgen [options] (--match=<name> ...) <file> [-- <clang-args>...]
   bindgen (-h | --help)
 
 Options:
@@ -63,7 +64,7 @@ struct Args {
     arg_clang_args: Vec<String>,
     flag_link: Option<String>,
     flag_output: String,
-    flag_match: Option<String>,
+    flag_match: Vec<String>,
     flag_builtins: bool,
     flag_emit_clang_ast: bool,
     flag_override_enum_type: String,
@@ -90,8 +91,8 @@ fn args_to_opts(args: Args) -> Builder<'static> {
     for arg in args.arg_clang_args {
         builder.clang_arg(arg);
     }
-    if let Some(s) = args.flag_match {
-        builder.match_pat(s);
+    for flag_match in args.flag_match {
+        builder.match_pat(flag_match);
     }
     if let Some(s) = args.flag_remove_prefix {
         builder.remove_prefix(s);


### PR DESCRIPTION
Note that it seems there were plans to add the `--match=<name>...` syntax support into docopt - https://github.com/docopt/docopt/issues/38#issuecomment-7068078 - but I've tried it with http://try.docopt.org and it doesn't work. Meaning we have to add a `Usage:` line for the multiple arguments option to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crabtw/rust-bindgen/363)
<!-- Reviewable:end -->
