### PR TITLE
Ignore typedefs if they would result in a cyclic reference in Rust.

### DIFF
--- a/tests/headers/cyclic.h
+++ b/tests/headers/cyclic.h
@@ -1,0 +1,4 @@
+typedef int type_t;
+typedef type_t my_type_t;
+typedef struct struct_t my_struct_t;
+typedef enum enum_t my_enum_t;

--- a/tests/test_prefix.rs
+++ b/tests/test_prefix.rs
@@ -1,4 +1,4 @@
-use bindgen::BindgenOptions;
+use bindgen::{Builder,BindgenOptions};
 use support::assert_bind_eq;
 
 #[test]
@@ -55,4 +55,17 @@ fn remove_prefix() {
             pub fn fn4() -> enum_;
         }
     ");
+}
+
+#[test]
+fn ignore_cyclic_references() {
+    let bindings = Builder::new("tests/headers/cyclic.h")
+        .remove_prefix("my_")
+        .generate()
+        .unwrap()
+        .to_string();
+    
+    assert!(!bindings.contains("pub type type_t = type_t;"));
+    assert!(!bindings.contains("pub type struct_t = struct_t;"));
+    assert!(!bindings.contains("pub type enum_t = enum_t;"));
 }


### PR DESCRIPTION
Because of the remove_prefix options, it's possible that a legitimate C typedef
would result in a cyclic Rust type alias, which results in compiler error
[E0391](https://doc.rust-lang.org/stable/error-index.html#E0391).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crabtw/rust-bindgen/365)
<!-- Reviewable:end -->
