### PR TITLE
Fix link_name attribute generation

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -1246,8 +1246,18 @@ fn mk_blob_field(ctx: &GenCtx, name: &str, layout: Layout, span: Span) -> ast::S
 }
 
 fn mk_link_name_attr(ctx: &mut GenCtx, name: &str) -> ast::Attribute {
-    let attr = format!("name = \"{}\"", name);
-    mk_attr(ctx, "link_name", &[&attr])
+    let attr = {
+        let k = ctx.ext_cx.name_of("link_name").as_str();
+        let v = ctx.ext_cx.name_of(name).as_str();
+        ctx.ext_cx.meta_name_value(ctx.span, k, ast::LitKind::Str(v,ast::StrStyle::Cooked))
+    };
+    respan(ctx.span,
+           ast::Attribute_ {
+               id: mk_attr_id(),
+               style: ast::AttrStyle::Outer,
+               value: attr,
+               is_sugared_doc: false,
+           })
 }
 
 fn mk_repr_attr(ctx: &mut GenCtx, layout: Layout) -> ast::Attribute {

--- a/tests/test_keywords.rs
+++ b/tests/test_keywords.rs
@@ -4,103 +4,103 @@ use support::assert_bind_eq;
 fn test_keywords() {
     assert_bind_eq(Default::default(), "headers/keywords.h", "
         extern \"C\" {
-            #[link_name(name = \"u8\")]
+            #[link_name = \"u8\"]
             pub static mut u8_: ::std::os::raw::c_int;
-            #[link_name(name = \"u16\")]
+            #[link_name = \"u16\"]
             pub static mut u16_: ::std::os::raw::c_int;
-            #[link_name(name = \"u32\")]
+            #[link_name = \"u32\"]
             pub static mut u32_: ::std::os::raw::c_int;
-            #[link_name(name = \"u64\")]
+            #[link_name = \"u64\"]
             pub static mut u64_: ::std::os::raw::c_int;
-            #[link_name(name = \"i8\")]
+            #[link_name = \"i8\"]
             pub static mut i8_: ::std::os::raw::c_int;
-            #[link_name(name = \"i16\")]
+            #[link_name = \"i16\"]
             pub static mut i16_: ::std::os::raw::c_int;
-            #[link_name(name = \"i32\")]
+            #[link_name = \"i32\"]
             pub static mut i32_: ::std::os::raw::c_int;
-            #[link_name(name = \"i64\")]
+            #[link_name = \"i64\"]
             pub static mut i64_: ::std::os::raw::c_int;
-            #[link_name(name = \"f32\")]
+            #[link_name = \"f32\"]
             pub static mut f32_: ::std::os::raw::c_int;
-            #[link_name(name = \"f64\")]
+            #[link_name = \"f64\"]
             pub static mut f64_: ::std::os::raw::c_int;
-            #[link_name(name = \"usize\")]
+            #[link_name = \"usize\"]
             pub static mut usize_: ::std::os::raw::c_int;
-            #[link_name(name = \"isize\")]
+            #[link_name = \"isize\"]
             pub static mut isize_: ::std::os::raw::c_int;
-            #[link_name(name = \"Self\")]
+            #[link_name = \"Self\"]
             pub static mut Self_: ::std::os::raw::c_int;
-            #[link_name(name = \"self\")]
+            #[link_name = \"self\"]
             pub static mut self_: ::std::os::raw::c_int;
-            #[link_name(name = \"as\")]
+            #[link_name = \"as\"]
             pub static mut as_: ::std::os::raw::c_int;
-            #[link_name(name = \"box\")]
+            #[link_name = \"box\"]
             pub static mut box_: ::std::os::raw::c_int;
-            #[link_name(name = \"crate\")]
+            #[link_name = \"crate\"]
             pub static mut crate_: ::std::os::raw::c_int;
-            #[link_name(name = \"false\")]
+            #[link_name = \"false\"]
             pub static mut false_: ::std::os::raw::c_int;
-            #[link_name(name = \"fn\")]
+            #[link_name = \"fn\"]
             pub static mut fn_: ::std::os::raw::c_int;
-            #[link_name(name = \"impl\")]
+            #[link_name = \"impl\"]
             pub static mut impl_: ::std::os::raw::c_int;
-            #[link_name(name = \"in\")]
+            #[link_name = \"in\"]
             pub static mut in_: ::std::os::raw::c_int;
-            #[link_name(name = \"let\")]
+            #[link_name = \"let\"]
             pub static mut let_: ::std::os::raw::c_int;
-            #[link_name(name = \"loop\")]
+            #[link_name = \"loop\"]
             pub static mut loop_: ::std::os::raw::c_int;
-            #[link_name(name = \"match\")]
+            #[link_name = \"match\"]
             pub static mut match_: ::std::os::raw::c_int;
-            #[link_name(name = \"mod\")]
+            #[link_name = \"mod\"]
             pub static mut mod_: ::std::os::raw::c_int;
-            #[link_name(name = \"move\")]
+            #[link_name = \"move\"]
             pub static mut move_: ::std::os::raw::c_int;
-            #[link_name(name = \"mut\")]
+            #[link_name = \"mut\"]
             pub static mut mut_: ::std::os::raw::c_int;
-            #[link_name(name = \"pub\")]
+            #[link_name = \"pub\"]
             pub static mut pub_: ::std::os::raw::c_int;
-            #[link_name(name = \"ref\")]
+            #[link_name = \"ref\"]
             pub static mut ref_: ::std::os::raw::c_int;
-            #[link_name(name = \"super\")]
+            #[link_name = \"super\"]
             pub static mut super_: ::std::os::raw::c_int;
-            #[link_name(name = \"trait\")]
+            #[link_name = \"trait\"]
             pub static mut trait_: ::std::os::raw::c_int;
-            #[link_name(name = \"true\")]
+            #[link_name = \"true\"]
             pub static mut true_: ::std::os::raw::c_int;
-            #[link_name(name = \"type\")]
+            #[link_name = \"type\"]
             pub static mut type_: ::std::os::raw::c_int;
-            #[link_name(name = \"unsafe\")]
+            #[link_name = \"unsafe\"]
             pub static mut unsafe_: ::std::os::raw::c_int;
-            #[link_name(name = \"use\")]
+            #[link_name = \"use\"]
             pub static mut use_: ::std::os::raw::c_int;
-            #[link_name(name = \"where\")]
+            #[link_name = \"where\"]
             pub static mut where_: ::std::os::raw::c_int;
-            #[link_name(name = \"abstract\")]
+            #[link_name = \"abstract\"]
             pub static mut abstract_: ::std::os::raw::c_int;
-            #[link_name(name = \"alignof\")]
+            #[link_name = \"alignof\"]
             pub static mut alignof_: ::std::os::raw::c_int;
-            #[link_name(name = \"become\")]
+            #[link_name = \"become\"]
             pub static mut become_: ::std::os::raw::c_int;
-            #[link_name(name = \"final\")]
+            #[link_name = \"final\"]
             pub static mut final_: ::std::os::raw::c_int;
-            #[link_name(name = \"macro\")]
+            #[link_name = \"macro\"]
             pub static mut macro_: ::std::os::raw::c_int;
-            #[link_name(name = \"offsetof\")]
+            #[link_name = \"offsetof\"]
             pub static mut offsetof_: ::std::os::raw::c_int;
-            #[link_name(name = \"override\")]
+            #[link_name = \"override\"]
             pub static mut override_: ::std::os::raw::c_int;
-            #[link_name(name = \"priv\")]
+            #[link_name = \"priv\"]
             pub static mut priv_: ::std::os::raw::c_int;
-            #[link_name(name = \"proc\")]
+            #[link_name = \"proc\"]
             pub static mut proc_: ::std::os::raw::c_int;
-            #[link_name(name = \"pure\")]
+            #[link_name = \"pure\"]
             pub static mut pure_: ::std::os::raw::c_int;
-            #[link_name(name = \"unsized\")]
+            #[link_name = \"unsized\"]
             pub static mut unsized_: ::std::os::raw::c_int;
-            #[link_name(name = \"virtual\")]
+            #[link_name = \"virtual\"]
             pub static mut virtual_: ::std::os::raw::c_int;
-            #[link_name(name = \"yield\")]
+            #[link_name = \"yield\"]
             pub static mut yield_: ::std::os::raw::c_int;
         }
     ");

--- a/tests/test_prefix.rs
+++ b/tests/test_prefix.rs
@@ -41,17 +41,17 @@ fn remove_prefix() {
             fn default() -> Self { unsafe { ::std::mem::zeroed() } }
         }
         extern \"C\" {
-            #[link_name(name = \"test_var\")]
+            #[link_name = \"test_var\"]
             pub static mut var: ::std::os::raw::c_int;
         }
         extern \"C\" {
-            #[link_name(name = \"test_fn\")]
+            #[link_name = \"test_fn\"]
             pub fn fn_() -> ::std::os::raw::c_int;
-            #[link_name(name = \"test_fn2\")]
+            #[link_name = \"test_fn2\"]
             pub fn fn2() -> union;
-            #[link_name(name = \"test_fn3\")]
+            #[link_name = \"test_fn3\"]
             pub fn fn3() -> struct_;
-            #[link_name(name = \"test_fn4\")]
+            #[link_name = \"test_fn4\"]
             pub fn fn4() -> enum_;
         }
     ");


### PR DESCRIPTION
The proper and only way to set the link name of an item is by using `#[link_name = "NAME"]`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crabtw/rust-bindgen/366)
<!-- Reviewable:end -->
