### PR TITLE
Add support for parsing macro definitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ log = "~0.3.6"
 # only for main, see https://github.com/rust-lang/cargo/issues/1982
 rustc-serialize = "~0.3.19"
 syntex_syntax = "~0.35.0"
+cexpr = "0.1.1"
 
 [dependencies.clippy]
 optional = true

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Remove `Builder::default` to force the specification of the C header file
   name.
 
+### Added
+- Add support for parsing complex macro definitions (integers only for now),
+  see `--convert-macros` (#370)
+
 ### Changed
 - Convert `float` and `double` to `f32` and `f64` by default (#348).
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,11 @@ Options:
   --no-rust-enums             Convert C enums to Rust constants instead of enums.
   --dont-convert-floats       Disables the convertion of C `float` and `double`
                               to Rust `f32` and `f64`.
+  --convert-macros            Try to convert macros into const definitions
+  --macro-int-types=<ty,...>  When converting macros, convert integers that
+                              would fit in a u8,u16,u32,u64,i8,i16,i32,i64 to
+                              the corresponding named C type, respectively. See
+                              `--override-enum-type` for the type names.
 ";
 
 #[derive(Debug, RustcDecodable)]
@@ -75,6 +80,8 @@ struct Args {
     flag_no_derive_debug: bool,
     flag_no_rust_enums: bool,
     flag_dont_convert_floats: bool,
+    flag_convert_macros: bool,
+    flag_macro_int_types: Option<String>,
 }
 
 fn args_to_opts(args: Args) -> Builder<'static> {
@@ -87,7 +94,8 @@ fn args_to_opts(args: Args) -> Builder<'static> {
            .use_core(args.flag_use_core)
            .derive_debug(!args.flag_no_derive_debug)
            .rust_enums(!args.flag_no_rust_enums)
-           .override_enum_ty(args.flag_override_enum_type);
+           .override_enum_ty(args.flag_override_enum_type)
+           .convert_macros(args.flag_convert_macros);
     for arg in args.arg_clang_args {
         builder.clang_arg(arg);
     }
@@ -96,6 +104,9 @@ fn args_to_opts(args: Args) -> Builder<'static> {
     }
     if let Some(s) = args.flag_remove_prefix {
         builder.remove_prefix(s);
+    }
+    if let Some(s) = args.flag_macro_int_types {
+        builder.macro_int_types(s.split(","));
     }
     if args.flag_builtins {
         builder.builtins();

--- a/tests/headers/defines.h
+++ b/tests/headers/defines.h
@@ -1,0 +1,3 @@
+#define MIN(a,b) (((a)<(b))?(a):(b))
+#define FLAG_10 (1<<9)
+#define ERROR -1

--- a/tests/test_defines.rs
+++ b/tests/test_defines.rs
@@ -1,0 +1,14 @@
+use bindgen::BindgenOptions;
+use support::assert_bind_eq;
+
+#[test]
+fn extern_defines() {
+    let opts=BindgenOptions {
+        convert_macros: true,
+        ..Default::default()
+    };
+    assert_bind_eq(opts, "headers/defines.h", "
+        pub const FLAG_10: ::std::os::raw::c_ushort = 512;
+        pub const ERROR: ::std::os::raw::c_char = -1;
+    ");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,6 +10,7 @@ mod support;
 //mod test_cmath;
 mod test_enum;
 mod test_decl;
+mod test_defines;
 mod test_extern;
 mod test_func;
 mod test_struct;


### PR DESCRIPTION
This uses [cexpr](https://crates.io/crates/cexpr) to parse the definitions.

Future improvements that I'm not going to work on any time soon, but shouldn't be too hard now that the parser is written:
* cexpr also supports parsing strings, chars, and floats, but bindgen can't currently define variables of those types.
* cexpr could also be used to enhance literal parsing for variables, replacing `parser.rs:visit_literal()`.

Fixes #56

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crabtw/rust-bindgen/370)
<!-- Reviewable:end -->
