### PR TITLE
Various fixes for enum types that are not converted into enums

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -1052,9 +1052,10 @@ fn cenum_to_rs(ctx: &mut GenCtx,
                                          .ty_ident(ctx.span, ctx.ext_cx.ident_of(enum_repr)))
                    .map(|p|ast::Item{vis:ast::Visibility::Public,..p}));
         for item in enum_items {
+            let rust_name = rust_id(ctx, &item.name, &options.remove_prefix).0;
             let value = cenum_value_to_int_lit(ctx, enum_is_signed, layout.size, item.val);
             items.push(ctx.ext_cx.item_const(ctx.span,
-                                             ctx.ext_cx.ident_of(&item.name),
+                                             ctx.ext_cx.ident_of(&rust_name),
                                              enum_ty.clone(),
                                              value)
                        .map(|p|ast::Item{vis:ast::Visibility::Public,..p}));

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -1049,13 +1049,15 @@ fn cenum_to_rs(ctx: &mut GenCtx,
         items.push(ctx.ext_cx.item_ty(ctx.span,
                                       enum_name,
                                       ctx.ext_cx
-                                         .ty_ident(ctx.span, ctx.ext_cx.ident_of(enum_repr))));
+                                         .ty_ident(ctx.span, ctx.ext_cx.ident_of(enum_repr)))
+                   .map(|p|ast::Item{vis:ast::Visibility::Public,..p}));
         for item in enum_items {
             let value = cenum_value_to_int_lit(ctx, enum_is_signed, layout.size, item.val);
             items.push(ctx.ext_cx.item_const(ctx.span,
                                              ctx.ext_cx.ident_of(&item.name),
                                              enum_ty.clone(),
-                                             value));
+                                             value)
+                       .map(|p|ast::Item{vis:ast::Visibility::Public,..p}));
         }
         return items;
     }

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -18,12 +18,12 @@ fn with_simple_enum() {
         pub enum Neg { MinusOne = -1, One = 1, }
     ");
     assert_bind_eq(default_without_rust_enums(), "headers/enum.h", "
-        type Foo = u32;
-        const Bar: Foo = 0;
-        const Qux: Foo = 1;
-        type Neg = i32;
-        const MinusOne: Neg = -1;
-        const One: Neg = 1;
+        pub type Foo = u32;
+        pub const Bar: Foo = 0;
+        pub const Qux: Foo = 1;
+        pub type Neg = i32;
+        pub const MinusOne: Neg = -1;
+        pub const One: Neg = 1;
     ");
 }
 
@@ -44,15 +44,15 @@ fn with_packed_enums() {
         pub enum Bigger { Much = 255, Larger = 256, }
     ");
     assert_bind_eq(default_without_rust_enums(), "headers/enum_packed.h", "
-        type Foo = u8;
-        const Bar: Foo = 0;
-        const Qux: Foo = 1;
-        type Neg = i8;
-        const MinusOne: Neg = -1;
-        const One: Neg = 1;
-        type Bigger = u16;
-        const Much: Bigger = 255;
-        const Larger: Bigger = 256;
+        pub type Foo = u8;
+        pub const Bar: Foo = 0;
+        pub const Qux: Foo = 1;
+        pub type Neg = i8;
+        pub const MinusOne: Neg = -1;
+        pub const One: Neg = 1;
+        pub type Bigger = u16;
+        pub const Much: Bigger = 255;
+        pub const Larger: Bigger = 256;
     ");
 }
 
@@ -66,9 +66,9 @@ fn with_duplicate_enum_value() {
         pub enum Foo { Bar = 1, }
     ");
     assert_bind_eq(default_without_rust_enums(), "headers/enum_dupe.h", "
-        type Foo = u32;
-        const Bar: Foo = 1;
-        const Dupe: Foo = 1;
+        pub type Foo = u32;
+        pub const Bar: Foo = 1;
+        pub const Dupe: Foo = 1;
     ");
 }
 
@@ -97,19 +97,19 @@ fn with_explicitly_typed_cxx_enum() {
         pub enum MuchLongLong { MuchHigh = 4294967296, }
     ");
     assert_bind_eq(default_without_rust_enums(), "headers/enum_explicit_type.hpp", "
-        type Foo = u8;
-        const Bar: Foo = 0;
-        const Qux: Foo = 1;
-        type Neg = i8;
-        const MinusOne: Neg = -1;
-        const One: Neg = 1;
-        type Bigger = u16;
-        const Much: Bigger = 255;
-        const Larger: Bigger = 256;
-        type MuchLong = i64;
-        const MuchLow: MuchLong = -4294967296;
-        type MuchLongLong = u64;
-        const MuchHigh: MuchLongLong = 4294967296;
+        pub type Foo = u8;
+        pub const Bar: Foo = 0;
+        pub const Qux: Foo = 1;
+        pub type Neg = i8;
+        pub const MinusOne: Neg = -1;
+        pub const One: Neg = 1;
+        pub type Bigger = u16;
+        pub const Much: Bigger = 255;
+        pub const Larger: Bigger = 256;
+        pub type MuchLong = i64;
+        pub const MuchLow: MuchLong = -4294967296;
+        pub type MuchLongLong = u64;
+        pub const MuchHigh: MuchLongLong = 4294967296;
     ");
 }
 
@@ -130,12 +130,12 @@ fn with_overflowed_enum_value() {
         pub enum Bar { One = 1, Big = 2, }
     ");
     assert_bind_eq(default_without_rust_enums(), "headers/overflowed_enum.hpp", "
-        type Foo = u32;
-        const BAP_ARM: Foo = 9698489;
-        const BAP_X86: Foo = 11960045;
-        const BAP_X86_64: Foo = 3128633167;
-        type Bar = u16;
-        const One: Bar = 1;
-        const Big: Bar = 2;
+        pub type Foo = u32;
+        pub const BAP_ARM: Foo = 9698489;
+        pub const BAP_X86: Foo = 11960045;
+        pub const BAP_X86_64: Foo = 3128633167;
+        pub type Bar = u16;
+        pub const One: Bar = 1;
+        pub const Big: Bar = 2;
     ");
 }

--- a/tests/test_prefix.rs
+++ b/tests/test_prefix.rs
@@ -58,6 +58,62 @@ fn remove_prefix() {
 }
 
 #[test]
+fn remove_prefix_no_enum() {
+    let opts = BindgenOptions {
+        remove_prefix: "test_".into(),
+        rust_enums: false,
+        ..Default::default()
+    };
+    assert_bind_eq(opts, "headers/prefix.h", "
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        #[derive(Debug)]
+        pub struct struct_ {
+            pub i: ::std::os::raw::c_int,
+        }
+        impl ::std::default::Default for struct_ {
+            fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+        }
+        pub type enum_ = u32;
+        pub const A: enum_ = 0;
+        pub const B: enum_ = 1;
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        #[derive(Debug)]
+        pub struct union {
+            pub _bindgen_data_: [u32; 1usize],
+        }
+        impl union {
+            pub unsafe fn s(&mut self) -> *mut struct_ {
+                let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
+                ::std::mem::transmute(raw.offset(0))
+            }
+            pub unsafe fn e(&mut self) -> *mut enum_ {
+                let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
+                ::std::mem::transmute(raw.offset(0))
+            }
+        }
+        impl ::std::default::Default for union {
+            fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+        }
+        extern \"C\" {
+            #[link_name = \"test_var\"]
+            pub static mut var: ::std::os::raw::c_int;
+        }
+        extern \"C\" {
+            #[link_name = \"test_fn\"]
+            pub fn fn_() -> ::std::os::raw::c_int;
+            #[link_name = \"test_fn2\"]
+            pub fn fn2() -> union;
+            #[link_name = \"test_fn3\"]
+            pub fn fn3() -> struct_;
+            #[link_name = \"test_fn4\"]
+            pub fn fn4() -> enum_;
+        }
+    ");
+}
+
+#[test]
 fn ignore_cyclic_references() {
     let bindings = Builder::new("tests/headers/cyclic.h")
         .remove_prefix("my_")


### PR DESCRIPTION
* Make types public
* Remove prefixes from the elements

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crabtw/rust-bindgen/371)
<!-- Reviewable:end -->
