### PR TITLE
Ignore the last ptr to a FuncProto

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Allow emission of -9223372036854775808 integer literal (#375)
+- Pointers to function pointers now generate the correct number of
+  indirections (#212)
 
 ## [0.18.0] - 2016-06-05
 ### Breaking

--- a/tests/headers/func_ptr.h
+++ b/tests/headers/func_ptr.h
@@ -1,1 +1,38 @@
 int (*foo) (int x, int y);
+
+void takes_argdef(void proc());
+void takes_argdef_ptr(void (*proc)());
+void takes_argdef_ptr_ptr(void (**proc)());
+
+// type with no indirection
+typedef void fn_t();
+void takes_tdef(fn_t proc);
+void takes_tdef_ptr(fn_t* proc);
+void takes_tdef_ptr_ptr(fn_t** proc);
+
+// types with one indirection, should be the same as no indirection
+typedef void (*fnptr_t)();
+void takes_tdefptr(fnptr_t proc);
+void takes_tdefptr_ptr(fnptr_t* proc);
+void takes_tdefptr_ptr_ptr(fnptr_t** proc);
+
+typedef fn_t *fntptr_t;
+void takes_tdeftptr(fntptr_t proc);
+void takes_tdeftptr_ptr(fntptr_t* proc);
+void takes_tdeftptr_ptr_ptr(fntptr_t** proc);
+
+// types with two indirection, effectively being one indirection
+typedef void (**fnptrptr_t)();
+void takes_tdefptrptr(fnptrptr_t proc);
+void takes_tdefptrptr_ptr(fnptrptr_t* proc);
+void takes_tdefptrptr_ptr_ptr(fnptrptr_t** proc);
+
+typedef fntptr_t *fntptrptr_t;
+void takes_tdeftptrtptr(fntptrptr_t proc);
+void takes_tdeftptrtptr_ptr(fntptrptr_t* proc);
+void takes_tdeftptrtptr_ptr_ptr(fntptrptr_t** proc);
+
+typedef fn_t **fntptrtptr_t;
+void takes_tdeftptrtptr(fntptrtptr_t proc);
+void takes_tdeftptrtptr_ptr(fntptrtptr_t* proc);
+void takes_tdeftptrtptr_ptr_ptr(fntptrtptr_t** proc);

--- a/tests/test_extern.rs
+++ b/tests/test_extern.rs
@@ -3,6 +3,6 @@ use support::assert_bind_eq;
 #[test]
 fn extern_c_in_hpp() {
     assert_bind_eq(Default::default(), "headers/extern.hpp", "
-        pub type foo = extern \"C\" fn(bar: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        pub type foo = ::std::option::Option<extern \"C\" fn(bar: ::std::os::raw::c_int) -> ::std::os::raw::c_int>;
     ");
 }

--- a/tests/test_func.rs
+++ b/tests/test_func.rs
@@ -63,24 +63,24 @@ fn func_ptr_in_struct() {
 #[test]
 fn func_proto() {
     assert_bind_eq(Default::default(), "headers/func_proto.h", "
-        pub type foo = extern \"C\" fn(bar: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        pub type foo = ::std::option::Option<extern \"C\" fn(bar: ::std::os::raw::c_int) -> ::std::os::raw::c_int>;
     ");
 }
 
 #[test]
 fn func_no_proto() {
     assert_bind_eq(Default::default(), "headers/func_no_proto.h", "
-        pub type no_proto = extern \"C\" fn() -> ::std::os::raw::c_int;
+        pub type no_proto = ::std::option::Option<extern \"C\" fn() -> ::std::os::raw::c_int>;
     ");
 }
 
 #[test]
 fn with_func_ptr_arg() {
     assert_bind_eq(Default::default(), "headers/func_with_func_ptr_arg.h", "
-        pub type ty = extern \"C\" fn() -> ::std::os::raw::c_int;
+        pub type ty = ::std::option::Option<extern \"C\" fn() -> ::std::os::raw::c_int>;
         extern \"C\" {
             pub fn foo(bar: ::std::option::Option<extern \"C\" fn()>);
-            pub fn function(proc_: *mut ty);
+            pub fn function(proc_: ty);
         }
     ");
 }

--- a/tests/test_func.rs
+++ b/tests/test_func.rs
@@ -2,13 +2,41 @@ use support::assert_bind_eq;
 
 #[test]
 fn func_ptr() {
-    assert_bind_eq(Default::default(), "headers/func_ptr.h", "
-        extern \"C\" {
-            pub static mut foo: ::std::option::Option<
-                extern \"C\" fn(x: ::std::os::raw::c_int,
-                              y: ::std::os::raw::c_int) -> ::std::os::raw::c_int>;
+    assert_bind_eq(Default::default(), "headers/func_ptr.h", r#"
+        pub type fn_t = ::std::option::Option<extern "C" fn()>;
+        pub type fnptr_t = ::std::option::Option<extern "C" fn()>;
+        pub type fntptr_t = fn_t;
+        pub type fnptrptr_t = *mut ::std::option::Option<extern "C" fn()>;
+        pub type fntptrptr_t = *mut fntptr_t;
+        pub type fntptrtptr_t = *mut fn_t;
+        extern "C" {
+            pub static mut foo:
+                       ::std::option::Option<extern "C" fn(x: ::std::os::raw::c_int,
+                                                           y: ::std::os::raw::c_int)
+                                                 -> ::std::os::raw::c_int>;
         }
-    ");
+        extern "C" {
+            pub fn takes_argdef(proc_: ::std::option::Option<extern "C" fn()>);
+            pub fn takes_argdef_ptr(proc_: ::std::option::Option<extern "C" fn()>);
+            pub fn takes_argdef_ptr_ptr(proc_:
+                                            *mut ::std::option::Option<extern "C" fn()>);
+            pub fn takes_tdef(proc_: fn_t);
+            pub fn takes_tdef_ptr(proc_: fn_t);
+            pub fn takes_tdef_ptr_ptr(proc_: *mut fn_t);
+            pub fn takes_tdefptr(proc_: fnptr_t);
+            pub fn takes_tdefptr_ptr(proc_: *mut fnptr_t);
+            pub fn takes_tdefptr_ptr_ptr(proc_: *mut *mut fnptr_t);
+            pub fn takes_tdeftptr(proc_: fntptr_t);
+            pub fn takes_tdeftptr_ptr(proc_: *mut fntptr_t);
+            pub fn takes_tdeftptr_ptr_ptr(proc_: *mut *mut fntptr_t);
+            pub fn takes_tdefptrptr(proc_: fnptrptr_t);
+            pub fn takes_tdefptrptr_ptr(proc_: *mut fnptrptr_t);
+            pub fn takes_tdefptrptr_ptr_ptr(proc_: *mut *mut fnptrptr_t);
+            pub fn takes_tdeftptrtptr(proc_: fntptrtptr_t);
+            pub fn takes_tdeftptrtptr_ptr(proc_: *mut fntptrtptr_t);
+            pub fn takes_tdeftptrtptr_ptr_ptr(proc_: *mut *mut fntptrtptr_t);
+        }
+    "#);
 }
 
 #[test]


### PR DESCRIPTION
Pointers to function pointers now generate the correct number of indirections

Fixes #212

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crabtw/rust-bindgen/375)
<!-- Reviewable:end -->
